### PR TITLE
Expanding character set for device names

### DIFF
--- a/drmem-api/src/types/device/name.rs
+++ b/drmem-api/src/types/device/name.rs
@@ -7,13 +7,11 @@ use std::str::FromStr;
 struct Segment(String);
 
 impl Segment {
-    // Returns `true` is the character can be used in a segment of the
+    // Returns `true` if the character can be used in a segment of the
     // device name.
 
     fn is_valid_char((idx, ch): (usize, char), len: usize) -> bool {
-        ('a'..='z').contains(&ch)
-            || ('A'..='Z').contains(&ch)
-            || ('0'..='9').contains(&ch)
+	ch.is_alphanumeric()
             || (ch == '-' && idx != 0 && idx != len - 1)
     }
 

--- a/drmem-api/src/types/device/name.rs
+++ b/drmem-api/src/types/device/name.rs
@@ -219,7 +219,14 @@ mod tests {
         assert!("a:b".parse::<Segment>().is_err());
         assert!("-a".parse::<Segment>().is_err());
         assert!("a-".parse::<Segment>().is_err());
+        assert!(" ".parse::<Segment>().is_err());
         assert_eq!(format!("{}", "a-b".parse::<Segment>().unwrap()), "a-b");
+
+	// Check non-ASCII entries.
+
+        assert!("٣".parse::<Segment>().is_ok());
+        assert!("温度".parse::<Segment>().is_ok());
+        assert!("🤖".parse::<Segment>().is_err());
     }
 
     #[test]
@@ -234,6 +241,7 @@ mod tests {
         assert_eq!(format!("{}", "a-b".parse::<Path>().unwrap()), "a-b");
         assert_eq!(format!("{}", "a:b".parse::<Path>().unwrap()), "a:b");
         assert_eq!(format!("{}", "a:b:c".parse::<Path>().unwrap()), "a:b:c");
+        assert_eq!(format!("{}", "家:温度".parse::<Path>().unwrap()), "家:温度");
     }
 
     #[test]


### PR DESCRIPTION
This pull request expands the characters we can use in device names. I added a couple of tests but they're not exhaustive. I wanted to test characters from cultures that don't use latin letters. So I used a Japanese example, which worked. I then tried using a Thai example but I couldn't get it to work. I'm not a Unicode expert so I don't know why Rust's `char::is_alphanumeric` function rejected some of the characters. If this project gets popular and some non-english speaking people find deficiencies, we can open another issue and do a more thorough job.

This resolves #12.