### PR TITLE
:sparkles: add `max_history` option to config

### DIFF
--- a/backends/drmem-db-simple/src/lib.rs
+++ b/backends/drmem-db-simple/src/lib.rs
@@ -137,6 +137,7 @@ impl Store for SimpleStore {
 
     async fn register_read_only_device(
         &mut self, driver: &str, name: &device::Name, units: &Option<String>,
+        _max_history: &Option<usize>,
     ) -> Result<(ReportReading, Option<device::Value>)> {
         // Check to see if the device name already exists.
 
@@ -191,6 +192,7 @@ impl Store for SimpleStore {
 
     async fn register_read_write_device(
         &mut self, driver: &str, name: &device::Name, units: &Option<String>,
+        _max_history: &Option<usize>,
     ) -> Result<(ReportReading, RxDeviceSetting, Option<device::Value>)> {
         // Check to see if the device name already exists.
 
@@ -380,8 +382,9 @@ mod tests {
         // Register a device named "junk" and associate it with the
         // driver named "test". We don't define units for this device.
 
-        if let Ok((f, None)) =
-            db.register_read_only_device("test", &name, &None).await
+        if let Ok((f, None)) = db
+            .register_read_only_device("test", &name, &None, &None)
+            .await
         {
             // Make sure the device was defined and the setting
             // channel is `None`.
@@ -407,15 +410,16 @@ mod tests {
             // driver name results in an error.
 
             assert!(db
-                .register_read_only_device("test2", &name, &None)
+                .register_read_only_device("test2", &name, &None, &None)
                 .await
                 .is_err());
 
             // Assert that re-registering this device with the same
             // driver name is successful.
 
-            if let Ok((f, Some(device::Value::Int(1)))) =
-                db.register_read_only_device("test", &name, &None).await
+            if let Ok((f, Some(device::Value::Int(1)))) = db
+                .register_read_only_device("test", &name, &None, &None)
+                .await
             {
                 // Also, verify that the device update channel wasn't
                 // disrupted by sending a value and receiving it from
@@ -439,8 +443,9 @@ mod tests {
         // Register a device named "junk" and associate it with the
         // driver named "test". We don't define units for this device.
 
-        if let Ok((f, mut set_chan, None)) =
-            db.register_read_write_device("test", &name, &None).await
+        if let Ok((f, mut set_chan, None)) = db
+            .register_read_write_device("test", &name, &None, &None)
+            .await
         {
             // Make sure the device was defined and a setting channel
             // has been created.
@@ -487,7 +492,7 @@ mod tests {
             // didn't affect the setting channel.
 
             assert!(db
-                .register_read_only_device("test2", &name, &None)
+                .register_read_only_device("test2", &name, &None, &None)
                 .await
                 .is_err());
             assert_eq!(
@@ -498,8 +503,9 @@ mod tests {
             // Assert that re-registering this device with the same
             // driver name is successful.
 
-            if let Ok((f, _, Some(device::Value::Int(1)))) =
-                db.register_read_write_device("test", &name, &None).await
+            if let Ok((f, _, Some(device::Value::Int(1)))) = db
+                .register_read_write_device("test", &name, &None, &None)
+                .await
             {
                 assert_eq!(
                     Err(TryRecvError::Disconnected),

--- a/drivers/drmem-drv-ntp/src/lib.rs
+++ b/drivers/drmem-drv-ntp/src/lib.rs
@@ -357,6 +357,7 @@ impl Instance {
 impl driver::API for Instance {
     fn create_instance(
         cfg: DriverConfig, core: driver::RequestChan,
+        max_history: Option<usize>,
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
@@ -371,16 +372,32 @@ impl driver::API for Instance {
                     // Define the devices managed by this driver.
 
                     let (d_state, _) = core
-                        .add_ro_device("state".parse::<Base>()?, None)
+                        .add_ro_device(
+                            "state".parse::<Base>()?,
+                            None,
+                            max_history,
+                        )
                         .await?;
                     let (d_source, _) = core
-                        .add_ro_device("source".parse::<Base>()?, None)
+                        .add_ro_device(
+                            "source".parse::<Base>()?,
+                            None,
+                            max_history,
+                        )
                         .await?;
                     let (d_offset, _) = core
-                        .add_ro_device("offset".parse::<Base>()?, Some("ms"))
+                        .add_ro_device(
+                            "offset".parse::<Base>()?,
+                            Some("ms"),
+                            max_history,
+                        )
                         .await?;
                     let (d_delay, _) = core
-                        .add_ro_device("delay".parse::<Base>()?, Some("ms"))
+                        .add_ro_device(
+                            "delay".parse::<Base>()?,
+                            Some("ms"),
+                            max_history,
+                        )
                         .await?;
 
                     return Ok(Box::new(Instance {

--- a/drivers/drmem-drv-sump/src/lib.rs
+++ b/drivers/drmem-drv-sump/src/lib.rs
@@ -243,6 +243,7 @@ impl Instance {
 impl driver::API for Instance {
     fn create_instance(
         cfg: DriverConfig, core: driver::RequestChan,
+        max_history: Option<usize>,
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
@@ -259,15 +260,21 @@ impl driver::API for Instance {
 
             // Define the devices managed by this driver.
 
-            let (d_service, _) =
-                core.add_ro_device("service".parse::<Base>()?, None).await?;
-            let (d_state, _) =
-                core.add_ro_device("state".parse::<Base>()?, None).await?;
+            let (d_service, _) = core
+                .add_ro_device("service".parse::<Base>()?, None, max_history)
+                .await?;
+            let (d_state, _) = core
+                .add_ro_device("state".parse::<Base>()?, None, max_history)
+                .await?;
             let (d_duty, _) = core
-                .add_ro_device("duty".parse::<Base>()?, Some("%"))
+                .add_ro_device("duty".parse::<Base>()?, Some("%"), max_history)
                 .await?;
             let (d_inflow, _) = core
-                .add_ro_device("in-flow".parse::<Base>()?, Some("gpm"))
+                .add_ro_device(
+                    "in-flow".parse::<Base>()?,
+                    Some("gpm"),
+                    max_history,
+                )
                 .await?;
 
             Ok(Box::new(Instance {

--- a/drivers/drmem-drv-weather-wu/src/lib.rs
+++ b/drivers/drmem-drv-weather-wu/src/lib.rs
@@ -278,6 +278,7 @@ impl Instance {
 impl driver::API for Instance {
     fn create_instance(
         cfg: DriverConfig, core: driver::RequestChan,
+        max_history: Option<usize>,
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
@@ -308,13 +309,25 @@ impl driver::API for Instance {
                     debug!("registering devices");
 
                     let (d_dewpt, _) = core
-                        .add_ro_device("dewpoint".parse::<Base>()?, temp_unit)
+                        .add_ro_device(
+                            "dewpoint".parse::<Base>()?,
+                            temp_unit,
+                            max_history,
+                        )
                         .await?;
                     let (d_htidx, _) = core
-                        .add_ro_device("heat-index".parse::<Base>()?, temp_unit)
+                        .add_ro_device(
+                            "heat-index".parse::<Base>()?,
+                            temp_unit,
+                            max_history,
+                        )
                         .await?;
                     let (d_humidity, _) = core
-                        .add_ro_device("humidity".parse::<Base>()?, Some("%"))
+                        .add_ro_device(
+                            "humidity".parse::<Base>()?,
+                            Some("%"),
+                            max_history,
+                        )
                         .await?;
                     let (d_prate, _) = core
                         .add_ro_device(
@@ -324,6 +337,7 @@ impl driver::API for Instance {
                             } else {
                                 "mm/hr"
                             }),
+                            max_history,
                         )
                         .await?;
 
@@ -335,6 +349,7 @@ impl driver::API for Instance {
                             } else {
                                 "mm"
                             }),
+                            max_history,
                         )
                         .await?;
 
@@ -346,6 +361,7 @@ impl driver::API for Instance {
                             } else {
                                 "hPa"
                             }),
+                            max_history,
                         )
                         .await?;
 
@@ -353,32 +369,52 @@ impl driver::API for Instance {
                         .add_ro_device(
                             "solar-rad".parse::<Base>()?,
                             Some("W/m²"),
+                            max_history,
                         )
                         .await?;
                     let (d_state, _) = core
-                        .add_ro_device("state".parse::<Base>()?, None)
+                        .add_ro_device(
+                            "state".parse::<Base>()?,
+                            None,
+                            max_history,
+                        )
                         .await?;
                     let (d_temp, _) = core
                         .add_ro_device(
                             "temperature".parse::<Base>()?,
                             temp_unit,
+                            max_history,
                         )
                         .await?;
-                    let (d_uv, _) =
-                        core.add_ro_device("uv".parse::<Base>()?, None).await?;
+                    let (d_uv, _) = core
+                        .add_ro_device("uv".parse::<Base>()?, None, max_history)
+                        .await?;
                     let (d_wndchl, _) = core
-                        .add_ro_device("wind-chill".parse::<Base>()?, temp_unit)
+                        .add_ro_device(
+                            "wind-chill".parse::<Base>()?,
+                            temp_unit,
+                            max_history,
+                        )
                         .await?;
                     let (d_wnddir, _) = core
-                        .add_ro_device("wind-dir".parse::<Base>()?, Some("°"))
+                        .add_ro_device(
+                            "wind-dir".parse::<Base>()?,
+                            Some("°"),
+                            max_history,
+                        )
                         .await?;
                     let (d_wndgst, _) = core
-                        .add_ro_device("wind-gust".parse::<Base>()?, speed_unit)
+                        .add_ro_device(
+                            "wind-gust".parse::<Base>()?,
+                            speed_unit,
+                            max_history,
+                        )
                         .await?;
                     let (d_wndspd, _) = core
                         .add_ro_device(
                             "wind-speed".parse::<Base>()?,
                             speed_unit,
+                            max_history,
                         )
                         .await?;
 

--- a/drmem-api/src/lib.rs
+++ b/drmem-api/src/lib.rs
@@ -21,7 +21,7 @@ pub trait Store {
 
     async fn register_read_only_device(
         &mut self, driver: &str, name: &types::device::Name,
-        units: &Option<String>,
+        units: &Option<String>, max_history: &Option<usize>,
     ) -> Result<(driver::ReportReading, Option<types::device::Value>)>;
 
     /// Used by a driver to define a read-write device. `name`
@@ -37,7 +37,7 @@ pub trait Store {
 
     async fn register_read_write_device(
         &mut self, driver: &str, name: &types::device::Name,
-        units: &Option<String>,
+        units: &Option<String>, max_history: &Option<usize>,
     ) -> Result<(
         driver::ReportReading,
         driver::RxDeviceSetting,

--- a/drmemd/src/core.rs
+++ b/drmemd/src/core.rs
@@ -41,11 +41,17 @@ impl State {
                 ref driver_name,
                 ref dev_name,
                 ref dev_units,
+                ref max_history,
                 rpy_chan,
             } => {
                 let result = self
                     .backend
-                    .register_read_only_device(driver_name, dev_name, dev_units)
+                    .register_read_only_device(
+                        driver_name,
+                        dev_name,
+                        dev_units,
+                        max_history,
+                    )
                     .await
                     .map_err(|_| Error::DeviceDefined(format!("{}", dev_name)));
 
@@ -58,6 +64,7 @@ impl State {
                 ref driver_name,
                 ref dev_name,
                 ref dev_units,
+                ref max_history,
                 rpy_chan,
             } => {
                 let result = self
@@ -66,6 +73,7 @@ impl State {
                         driver_name,
                         dev_name,
                         dev_units,
+                        max_history,
                     )
                     .await
                     .map_err(|_| Error::DeviceDefined(format!("{}", dev_name)));

--- a/drmemd/src/driver/drv_cycle.rs
+++ b/drmemd/src/driver/drv_cycle.rs
@@ -143,6 +143,7 @@ impl Instance {
 impl driver::API for Instance {
     fn create_instance(
         cfg: DriverConfig, core: driver::RequestChan,
+        max_history: Option<usize>,
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
@@ -154,10 +155,12 @@ impl driver::API for Instance {
 
             // Define the devices managed by this driver.
 
-            let (d_output, _) =
-                core.add_ro_device("output".parse::<Base>()?, None).await?;
-            let (d_enable, rx_set, _) =
-                core.add_rw_device("enable".parse::<Base>()?, None).await?;
+            let (d_output, _) = core
+                .add_ro_device("output".parse::<Base>()?, None, max_history)
+                .await?;
+            let (d_enable, rx_set, _) = core
+                .add_rw_device("enable".parse::<Base>()?, None, max_history)
+                .await?;
 
             Ok(Box::new(Instance::new(
                 enabled, millis, d_output, d_enable, rx_set,

--- a/drmemd/src/driver/drv_timer.rs
+++ b/drmemd/src/driver/drv_timer.rs
@@ -178,6 +178,7 @@ impl Instance {
 impl driver::API for Instance {
     fn create_instance(
         cfg: DriverConfig, core: driver::RequestChan,
+        max_history: Option<usize>,
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
@@ -189,10 +190,12 @@ impl driver::API for Instance {
 
             // Define the devices managed by this driver.
 
-            let (d_output, _) =
-                core.add_ro_device("output".parse::<Base>()?, None).await?;
-            let (d_enable, rx_set, _) =
-                core.add_rw_device("enable".parse::<Base>()?, None).await?;
+            let (d_output, _) = core
+                .add_ro_device("output".parse::<Base>()?, None, max_history)
+                .await?;
+            let (d_enable, rx_set, _) = core
+                .add_rw_device("enable".parse::<Base>()?, None, max_history)
+                .await?;
 
             Ok(Box::new(Instance::new(
                 level, millis, d_output, d_enable, rx_set,

--- a/drmemd/src/main.rs
+++ b/drmemd/src/main.rs
@@ -110,6 +110,7 @@ async fn run() -> Result<()> {
                     RequestChan::new(&driver_name, &driver.prefix, &tx_drv_req);
                 let instance = driver_info.run_instance(
                     driver_name,
+                    driver.max_history,
                     driver.cfg.unwrap_or_default().clone(),
                     chan,
                 );


### PR DESCRIPTION
The TOML config file now supports an optional `max_history`, integer field for each driver instance. This parameter is a hint to the backend storage as to how many data point should be stored for the device.

This commit resolves issue #24.