### PR TITLE
Clean up some code

### DIFF
--- a/drivers/drmem-drv-ntp/src/lib.rs
+++ b/drivers/drmem-drv-ntp/src/lib.rs
@@ -361,6 +361,15 @@ impl driver::API for Instance {
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
+        // It's safe to use `.unwrap()` for these names because, in a
+        // fully-tested, released version of this driver, we would
+        // have seen and fixed any panics.
+
+        let state_name = "state".parse::<Base>().unwrap();
+        let source_name = "source".parse::<Base>().unwrap();
+        let offset_name = "offset".parse::<Base>().unwrap();
+        let delay_name = "delay".parse::<Base>().unwrap();
+
         let fut = async move {
             // Validate the configuration.
 
@@ -372,32 +381,16 @@ impl driver::API for Instance {
                     // Define the devices managed by this driver.
 
                     let (d_state, _) = core
-                        .add_ro_device(
-                            "state".parse::<Base>()?,
-                            None,
-                            max_history,
-                        )
+                        .add_ro_device(state_name, None, max_history)
                         .await?;
                     let (d_source, _) = core
-                        .add_ro_device(
-                            "source".parse::<Base>()?,
-                            None,
-                            max_history,
-                        )
+                        .add_ro_device(source_name, None, max_history)
                         .await?;
                     let (d_offset, _) = core
-                        .add_ro_device(
-                            "offset".parse::<Base>()?,
-                            Some("ms"),
-                            max_history,
-                        )
+                        .add_ro_device(offset_name, Some("ms"), max_history)
                         .await?;
                     let (d_delay, _) = core
-                        .add_ro_device(
-                            "delay".parse::<Base>()?,
-                            Some("ms"),
-                            max_history,
-                        )
+                        .add_ro_device(delay_name, Some("ms"), max_history)
                         .await?;
 
                     return Ok(Box::new(Instance {

--- a/drivers/drmem-drv-sump/README.md
+++ b/drivers/drmem-drv-sump/README.md
@@ -1,7 +1,7 @@
 # drmem-drv-sump
 
 This driver monitors the state of a sump pump through a custom,
-non-commercial interface and updates a set of devices based on its
+non-commercial interface[^1] and updates a set of devices based on its
 behavior.
 
 The sump pump state is obtained, via TCP, with a RaspberryPi that's
@@ -59,3 +59,9 @@ inaccuracy of the measurements.
 ## History
 
 Added in v0.1.0.
+
+[^1]: The remote end is running on a Raspberry Pi loaded with NetBSD
+    9.0. The source code can be found
+    [here](https://github.com/rneswold/drmem-drv-sump). The GPIO code
+    is specific to NetBSD, so adjustments will have to be made for
+    Linux.

--- a/drivers/drmem-drv-sump/src/lib.rs
+++ b/drivers/drmem-drv-sump/src/lib.rs
@@ -247,6 +247,11 @@ impl driver::API for Instance {
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
+        let service_name = "service".parse::<Base>().unwrap();
+        let state_name = "state".parse::<Base>().unwrap();
+        let duty_name = "duty".parse::<Base>().unwrap();
+        let in_flow_name = "in-flow".parse::<Base>().unwrap();
+
         let fut = async move {
             // Validate the configuration.
 
@@ -260,21 +265,15 @@ impl driver::API for Instance {
 
             // Define the devices managed by this driver.
 
-            let (d_service, _) = core
-                .add_ro_device("service".parse::<Base>()?, None, max_history)
-                .await?;
-            let (d_state, _) = core
-                .add_ro_device("state".parse::<Base>()?, None, max_history)
-                .await?;
+            let (d_service, _) =
+                core.add_ro_device(service_name, None, max_history).await?;
+            let (d_state, _) =
+                core.add_ro_device(state_name, None, max_history).await?;
             let (d_duty, _) = core
-                .add_ro_device("duty".parse::<Base>()?, Some("%"), max_history)
+                .add_ro_device(duty_name, Some("%"), max_history)
                 .await?;
             let (d_inflow, _) = core
-                .add_ro_device(
-                    "in-flow".parse::<Base>()?,
-                    Some("gpm"),
-                    max_history,
-                )
+                .add_ro_device(in_flow_name, Some("gpm"), max_history)
                 .await?;
 
             Ok(Box::new(Instance {

--- a/drivers/drmem-drv-weather-wu/src/lib.rs
+++ b/drivers/drmem-drv-weather-wu/src/lib.rs
@@ -282,6 +282,21 @@ impl driver::API for Instance {
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
+        let dewpoint_name = "dewpoint".parse::<Base>().unwrap();
+        let heat_index_name = "heat-index".parse::<Base>().unwrap();
+        let humidity_name = "humidity".parse::<Base>().unwrap();
+        let precip_rate_name = "precip-rate".parse::<Base>().unwrap();
+        let precip_total_name = "precip-total".parse::<Base>().unwrap();
+        let pressure_name = "pressure".parse::<Base>().unwrap();
+        let solar_rad_name = "solar-rad".parse::<Base>().unwrap();
+        let state_name = "state".parse::<Base>().unwrap();
+        let temperature_name = "temperature".parse::<Base>().unwrap();
+        let uv_name = "uv".parse::<Base>().unwrap();
+        let wind_chill_name = "wind-chill".parse::<Base>().unwrap();
+        let wind_dir_name = "wind-dir".parse::<Base>().unwrap();
+        let wind_gust_name = "wind-gust".parse::<Base>().unwrap();
+        let wind_speed_name = "wind-speed".parse::<Base>().unwrap();
+
         let fut = async move {
             match wu::create_client(Duration::from_secs(5)) {
                 Ok(mut con) => {
@@ -309,29 +324,17 @@ impl driver::API for Instance {
                     debug!("registering devices");
 
                     let (d_dewpt, _) = core
-                        .add_ro_device(
-                            "dewpoint".parse::<Base>()?,
-                            temp_unit,
-                            max_history,
-                        )
+                        .add_ro_device(dewpoint_name, temp_unit, max_history)
                         .await?;
                     let (d_htidx, _) = core
-                        .add_ro_device(
-                            "heat-index".parse::<Base>()?,
-                            temp_unit,
-                            max_history,
-                        )
+                        .add_ro_device(heat_index_name, temp_unit, max_history)
                         .await?;
                     let (d_humidity, _) = core
-                        .add_ro_device(
-                            "humidity".parse::<Base>()?,
-                            Some("%"),
-                            max_history,
-                        )
+                        .add_ro_device(humidity_name, Some("%"), max_history)
                         .await?;
                     let (d_prate, _) = core
                         .add_ro_device(
-                            "precip-rate".parse::<Base>()?,
+                            precip_rate_name,
                             Some(if let wu::Unit::English = units {
                                 "in/hr"
                             } else {
@@ -343,7 +346,7 @@ impl driver::API for Instance {
 
                     let (d_ptotal, precip_int) = core
                         .add_ro_device(
-                            "precip-total".parse::<Base>()?,
+                            precip_total_name,
                             Some(if let wu::Unit::English = units {
                                 "in"
                             } else {
@@ -355,7 +358,7 @@ impl driver::API for Instance {
 
                     let (d_pressure, _) = core
                         .add_ro_device(
-                            "pressure".parse::<Base>()?,
+                            pressure_name,
                             Some(if let wu::Unit::English = units {
                                 "inHg"
                             } else {
@@ -367,55 +370,30 @@ impl driver::API for Instance {
 
                     let (d_solrad, _) = core
                         .add_ro_device(
-                            "solar-rad".parse::<Base>()?,
+                            solar_rad_name,
                             Some("W/m²"),
                             max_history,
                         )
                         .await?;
                     let (d_state, _) = core
-                        .add_ro_device(
-                            "state".parse::<Base>()?,
-                            None,
-                            max_history,
-                        )
+                        .add_ro_device(state_name, None, max_history)
                         .await?;
                     let (d_temp, _) = core
-                        .add_ro_device(
-                            "temperature".parse::<Base>()?,
-                            temp_unit,
-                            max_history,
-                        )
+                        .add_ro_device(temperature_name, temp_unit, max_history)
                         .await?;
-                    let (d_uv, _) = core
-                        .add_ro_device("uv".parse::<Base>()?, None, max_history)
-                        .await?;
+                    let (d_uv, _) =
+                        core.add_ro_device(uv_name, None, max_history).await?;
                     let (d_wndchl, _) = core
-                        .add_ro_device(
-                            "wind-chill".parse::<Base>()?,
-                            temp_unit,
-                            max_history,
-                        )
+                        .add_ro_device(wind_chill_name, temp_unit, max_history)
                         .await?;
                     let (d_wnddir, _) = core
-                        .add_ro_device(
-                            "wind-dir".parse::<Base>()?,
-                            Some("°"),
-                            max_history,
-                        )
+                        .add_ro_device(wind_dir_name, Some("°"), max_history)
                         .await?;
                     let (d_wndgst, _) = core
-                        .add_ro_device(
-                            "wind-gust".parse::<Base>()?,
-                            speed_unit,
-                            max_history,
-                        )
+                        .add_ro_device(wind_gust_name, speed_unit, max_history)
                         .await?;
                     let (d_wndspd, _) = core
-                        .add_ro_device(
-                            "wind-speed".parse::<Base>()?,
-                            speed_unit,
-                            max_history,
-                        )
+                        .add_ro_device(wind_speed_name, speed_unit, max_history)
                         .await?;
 
                     // If a previous value of the integration is

--- a/drmemd/src/driver/drv_cycle.md
+++ b/drmemd/src/driver/drv_cycle.md
@@ -12,8 +12,8 @@ This driver uses the following configuration parameters.
 
 - `millis` is the number of milliseconds for the full cycle.
 - `enabled` is an optional boolean value which, when `true`, will set
-  the `enable` device's initial value to `true`. If not provided, it
-  defaults to `false`.
+  the `enable` device's initial value to `true` and, therefore, start
+  the cycling at boot time. If not provided, it defaults to `false`.
 
 ## Devices
 
@@ -27,8 +27,7 @@ The driver creates these devices:
 Every value sent to the `enable` device will be reported -- even
 duplicates. This allows one to, if using the redis backend, see the
 history of settings made to the device. The `output` device, however,
-only reports state changes. So if a client sends multiple `true`
-values, the `output` would only report the state changes.
+only reports state changes.
 
 ## History
 


### PR DESCRIPTION
While looking at the driver code, I didn't like that defining the device names could return an error. These are constant values and, once correctly defined, will never change. So the main portion of this pull request is to move those definitions outside the future that is returned.