### PR TITLE
:bug: pass down `redis` feature

### DIFF
--- a/drmemd/Cargo.toml
+++ b/drmemd/Cargo.toml
@@ -88,7 +88,7 @@ default = ["simple-backend"]
 # Backends
 
 simple-backend = ["drmem-db-simple"]
-redis-backend = ["drmem-db-redis"]
+redis-backend = ["drmem-db-redis", "drmem-config/redis-backend"]
 
 # Client APIs
 


### PR DESCRIPTION
When selecting the `redis-backend` feature, we weren't passing it to the `drmem-config` crate.