### PR TITLE
Pr issue13

### DIFF
--- a/backends/drmem-db-redis/src/lib.rs
+++ b/backends/drmem-db-redis/src/lib.rs
@@ -749,7 +749,7 @@ impl RedisStore {
 
     fn mk_report_func(
         &self, name: &str, max_history: &Option<usize>,
-    ) -> ReportReading {
+    ) -> ReportReading<Value> {
         let db_con = self.db_con.clone();
         let name = String::from(name);
 
@@ -795,7 +795,7 @@ impl Store for RedisStore {
     async fn register_read_only_device(
         &mut self, driver_name: &str, name: &device::Name,
         units: &Option<String>, max_history: &Option<usize>,
-    ) -> Result<(ReportReading, Option<Value>)> {
+    ) -> Result<(ReportReading<Value>, Option<Value>)> {
         let name = name.to_string();
 
         debug!("registering '{}' as read-only", &name);
@@ -814,7 +814,7 @@ impl Store for RedisStore {
     async fn register_read_write_device(
         &mut self, driver_name: &str, name: &device::Name,
         units: &Option<String>, max_history: &Option<usize>,
-    ) -> Result<(ReportReading, RxDeviceSetting, Option<Value>)> {
+    ) -> Result<(ReportReading<Value>, RxDeviceSetting, Option<Value>)> {
         let sname = name.to_string();
 
         debug!("registering '{}' as read-write", &sname);

--- a/backends/drmem-db-simple/src/lib.rs
+++ b/backends/drmem-db-simple/src/lib.rs
@@ -73,7 +73,9 @@ pub async fn open(_cfg: &config::Config) -> Result<impl Store> {
 // Builds the `ReportReading` function. Drivers will call specialized
 // instances of this function to record the latest value of a device.
 
-fn mk_report_func(di: &DeviceInfo, name: &device::Name) -> ReportReading {
+fn mk_report_func(
+    di: &DeviceInfo, name: &device::Name,
+) -> ReportReading<device::Value> {
     let reading = di.reading.clone();
     let name = name.to_string();
 
@@ -140,7 +142,7 @@ impl Store for SimpleStore {
     async fn register_read_only_device(
         &mut self, driver: &str, name: &device::Name, units: &Option<String>,
         _max_history: &Option<usize>,
-    ) -> Result<(ReportReading, Option<device::Value>)> {
+    ) -> Result<(ReportReading<device::Value>, Option<device::Value>)> {
         // Check to see if the device name already exists.
 
         match self.0.entry((*name).clone()) {
@@ -195,7 +197,11 @@ impl Store for SimpleStore {
     async fn register_read_write_device(
         &mut self, driver: &str, name: &device::Name, units: &Option<String>,
         _max_history: &Option<usize>,
-    ) -> Result<(ReportReading, RxDeviceSetting, Option<device::Value>)> {
+    ) -> Result<(
+        ReportReading<device::Value>,
+        RxDeviceSetting,
+        Option<device::Value>,
+    )> {
         // Check to see if the device name already exists.
 
         match self.0.entry((*name).clone()) {

--- a/drivers/drmem-drv-ntp/src/lib.rs
+++ b/drivers/drmem-drv-ntp/src/lib.rs
@@ -1,6 +1,6 @@
 use drmem_api::{
     driver::{self, DriverConfig},
-    types::{device::Base, Error},
+    types::{device, Error},
     Result,
 };
 use std::future::Future;
@@ -105,10 +105,10 @@ mod server {
 pub struct Instance {
     sock: UdpSocket,
     seq: u16,
-    d_state: driver::ReportReading,
-    d_source: driver::ReportReading,
-    d_offset: driver::ReportReading,
-    d_delay: driver::ReportReading,
+    d_state: driver::ReportReading<device::Value>,
+    d_source: driver::ReportReading<device::Value>,
+    d_offset: driver::ReportReading<device::Value>,
+    d_delay: driver::ReportReading<device::Value>,
 }
 
 impl Instance {
@@ -365,10 +365,10 @@ impl driver::API for Instance {
         // fully-tested, released version of this driver, we would
         // have seen and fixed any panics.
 
-        let state_name = "state".parse::<Base>().unwrap();
-        let source_name = "source".parse::<Base>().unwrap();
-        let offset_name = "offset".parse::<Base>().unwrap();
-        let delay_name = "delay".parse::<Base>().unwrap();
+        let state_name = "state".parse::<device::Base>().unwrap();
+        let source_name = "source".parse::<device::Base>().unwrap();
+        let offset_name = "offset".parse::<device::Base>().unwrap();
+        let delay_name = "delay".parse::<device::Base>().unwrap();
 
         let fut = async move {
             // Validate the configuration.

--- a/drivers/drmem-drv-ntp/src/lib.rs
+++ b/drivers/drmem-drv-ntp/src/lib.rs
@@ -105,10 +105,10 @@ mod server {
 pub struct Instance {
     sock: UdpSocket,
     seq: u16,
-    d_state: driver::ReportReading<device::Value>,
-    d_source: driver::ReportReading<device::Value>,
-    d_offset: driver::ReportReading<device::Value>,
-    d_delay: driver::ReportReading<device::Value>,
+    d_state: driver::ReportReading<bool>,
+    d_source: driver::ReportReading<String>,
+    d_offset: driver::ReportReading<f64>,
+    d_delay: driver::ReportReading<f64>,
 }
 
 impl Instance {
@@ -451,10 +451,10 @@ impl driver::API for Instance {
                                     tmp.get_offset(),
                                     tmp.get_delay()
                                 );
-                                (self.d_source)(tmp.get_host().into()).await;
-                                (self.d_offset)(tmp.get_offset().into()).await;
-                                (self.d_delay)(tmp.get_delay().into()).await;
-                                (self.d_state)(true.into()).await;
+                                (self.d_source)(tmp.get_host().clone()).await;
+                                (self.d_offset)(tmp.get_offset()).await;
+                                (self.d_delay)(tmp.get_delay()).await;
+                                (self.d_state)(true).await;
                                 info = host_info;
                             }
                             continue;
@@ -463,14 +463,14 @@ impl driver::API for Instance {
                             if info.is_some() {
                                 warn!("no synced host information found");
                                 info = None;
-                                (self.d_state)(false.into()).await;
+                                (self.d_state)(false).await;
                             }
                         }
                     }
                 } else if info.is_some() {
                     warn!("we're not synced to any host");
                     info = None;
-                    (self.d_state)(false.into()).await;
+                    (self.d_state)(false).await;
                 }
             }
         };

--- a/drivers/drmem-drv-sump/src/lib.rs
+++ b/drivers/drmem-drv-sump/src/lib.rs
@@ -1,6 +1,6 @@
 use drmem_api::{
     driver::{self, DriverConfig},
-    types::{device::Base, Error},
+    types::{device, Error},
     Result,
 };
 use std::future::Future;
@@ -144,10 +144,10 @@ pub struct Instance {
     gpm: f64,
     rx: OwnedReadHalf,
     _tx: OwnedWriteHalf,
-    d_service: driver::ReportReading,
-    d_state: driver::ReportReading,
-    d_duty: driver::ReportReading,
-    d_inflow: driver::ReportReading,
+    d_service: driver::ReportReading<device::Value>,
+    d_state: driver::ReportReading<device::Value>,
+    d_duty: driver::ReportReading<device::Value>,
+    d_inflow: driver::ReportReading<device::Value>,
 }
 
 impl Instance {
@@ -247,10 +247,10 @@ impl driver::API for Instance {
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
-        let service_name = "service".parse::<Base>().unwrap();
-        let state_name = "state".parse::<Base>().unwrap();
-        let duty_name = "duty".parse::<Base>().unwrap();
-        let in_flow_name = "in-flow".parse::<Base>().unwrap();
+        let service_name = "service".parse::<device::Base>().unwrap();
+        let state_name = "state".parse::<device::Base>().unwrap();
+        let duty_name = "duty".parse::<device::Base>().unwrap();
+        let in_flow_name = "in-flow".parse::<device::Base>().unwrap();
 
         let fut = async move {
             // Validate the configuration.

--- a/drivers/drmem-drv-sump/src/lib.rs
+++ b/drivers/drmem-drv-sump/src/lib.rs
@@ -144,10 +144,10 @@ pub struct Instance {
     gpm: f64,
     rx: OwnedReadHalf,
     _tx: OwnedWriteHalf,
-    d_service: driver::ReportReading<device::Value>,
-    d_state: driver::ReportReading<device::Value>,
-    d_duty: driver::ReportReading<device::Value>,
-    d_inflow: driver::ReportReading<device::Value>,
+    d_service: driver::ReportReading<bool>,
+    d_state: driver::ReportReading<bool>,
+    d_duty: driver::ReportReading<f64>,
+    d_inflow: driver::ReportReading<f64>,
 }
 
 impl Instance {
@@ -308,13 +308,13 @@ impl driver::API for Instance {
                 Span::current().record("cfg", &addr.as_str());
             }
 
-            (self.d_service)(true.into()).await;
+            (self.d_service)(true).await;
 
             loop {
                 match self.get_reading().await {
                     Ok((stamp, true)) => {
                         if self.state.on_event(stamp) {
-                            (self.d_state)(true.into()).await;
+                            (self.d_state)(true).await;
                         }
                     }
 
@@ -331,15 +331,15 @@ impl driver::API for Instance {
                                 in_flow
                             );
 
-                            (self.d_state)(false.into()).await;
-                            (self.d_duty)(duty.into()).await;
-                            (self.d_inflow)(in_flow.into()).await;
+                            (self.d_state)(false).await;
+                            (self.d_duty)(duty).await;
+                            (self.d_inflow)(in_flow).await;
                         }
                     }
 
                     Err(e) => {
-                        (self.d_state)(false.into()).await;
-                        (self.d_service)(false.into()).await;
+                        (self.d_state)(false).await;
+                        (self.d_service)(false).await;
                         panic!("couldn't read sump state -- {:?}", e);
                     }
                 }

--- a/drivers/drmem-drv-weather-wu/src/lib.rs
+++ b/drivers/drmem-drv-weather-wu/src/lib.rs
@@ -400,11 +400,7 @@ impl driver::API for Instance {
                     // provided, initialize the state to
                     // it. Otherwise, set it to 0.0.
 
-                    let precip_int = if let Some(v) = precip_int {
-                        f64::try_from(v).unwrap_or(0.0)
-                    } else {
-                        0.0
-                    };
+                    let precip_int = precip_int.unwrap_or(0.0);
 
                     // Assemble and return the state of the driver.
 

--- a/drivers/drmem-drv-weather-wu/src/lib.rs
+++ b/drivers/drmem-drv-weather-wu/src/lib.rs
@@ -22,20 +22,20 @@ pub struct Instance {
     precip_int: f64,
     prev_precip_total: Option<f64>,
 
-    d_dewpt: driver::ReportReading<device::Value>,
-    d_htidx: driver::ReportReading<device::Value>,
-    d_humidity: driver::ReportReading<device::Value>,
-    d_prate: driver::ReportReading<device::Value>,
-    d_ptotal: driver::ReportReading<device::Value>,
-    d_pressure: driver::ReportReading<device::Value>,
-    d_solrad: driver::ReportReading<device::Value>,
-    d_state: driver::ReportReading<device::Value>,
-    d_temp: driver::ReportReading<device::Value>,
-    d_uv: driver::ReportReading<device::Value>,
-    d_wndchl: driver::ReportReading<device::Value>,
-    d_wnddir: driver::ReportReading<device::Value>,
-    d_wndgst: driver::ReportReading<device::Value>,
-    d_wndspd: driver::ReportReading<device::Value>,
+    d_dewpt: driver::ReportReading<f64>,
+    d_htidx: driver::ReportReading<f64>,
+    d_humidity: driver::ReportReading<f64>,
+    d_prate: driver::ReportReading<f64>,
+    d_ptotal: driver::ReportReading<f64>,
+    d_pressure: driver::ReportReading<f64>,
+    d_solrad: driver::ReportReading<f64>,
+    d_state: driver::ReportReading<bool>,
+    d_temp: driver::ReportReading<f64>,
+    d_uv: driver::ReportReading<f64>,
+    d_wndchl: driver::ReportReading<f64>,
+    d_wnddir: driver::ReportReading<f64>,
+    d_wndgst: driver::ReportReading<f64>,
+    d_wndspd: driver::ReportReading<f64>,
 }
 
 impl Instance {
@@ -158,7 +158,7 @@ impl Instance {
 
         if let Some(dewpt) = dewpt {
             if (0.0..=200.0).contains(&dewpt) {
-                (self.d_dewpt)(dewpt.into()).await
+                (self.d_dewpt)(dewpt).await
             } else {
                 warn!("ignoring bad dew point value: {:.1}", dewpt)
             }
@@ -166,7 +166,7 @@ impl Instance {
 
         if let Some(htidx) = htidx {
             if (0.0..=200.0).contains(&htidx) {
-                (self.d_htidx)(htidx.into()).await
+                (self.d_htidx)(htidx).await
             } else {
                 warn!("ignoring bad heat index value: {:.1}", htidx)
             }
@@ -174,7 +174,7 @@ impl Instance {
 
         if let (Some(prate), Some(ptotal)) = (prate, ptotal) {
             if (0.0..=24.0).contains(&prate) {
-                (self.d_prate)(prate.into()).await
+                (self.d_prate)(prate).await
             } else {
                 warn!("ignoring bad precip rate: {:.2}", prate)
             }
@@ -197,7 +197,7 @@ impl Instance {
                         debug!("precip calc: stable sum, no rain ... resetting sum");
                         self.precip_int = 0.0
                     }
-                    (self.d_ptotal)(self.precip_int.into()).await
+                    (self.d_ptotal)(self.precip_int).await
                 }
                 self.prev_precip_total = Some(ptotal);
             } else {
@@ -208,23 +208,23 @@ impl Instance {
         }
 
         if let Some(press) = press {
-            (self.d_pressure)(press.into()).await
+            (self.d_pressure)(press).await
         }
 
         if let Some(temp) = temp {
-            (self.d_temp)(temp.into()).await
+            (self.d_temp)(temp).await
         }
 
         if let Some(wndchl) = wndchl {
-            (self.d_wndchl)(wndchl.into()).await
+            (self.d_wndchl)(wndchl).await
         }
 
         if let Some(wndgst) = wndgst {
-            (self.d_wndgst)(wndgst.into()).await
+            (self.d_wndgst)(wndgst).await
         }
 
         if let Some(wndspd) = wndspd {
-            (self.d_wndspd)(wndspd.into()).await
+            (self.d_wndspd)(wndspd).await
         }
 
         // If solar radiation readings are provided, report them.
@@ -236,7 +236,7 @@ impl Instance {
             // slightly inaccurate sensors won't be ignored.
 
             if (0.0..=1400.0).contains(&sol_rad) {
-                (self.d_solrad)(sol_rad.into()).await
+                (self.d_solrad)(sol_rad).await
             } else {
                 warn!("ignoring bad solar radiation value: {:.1}", sol_rad)
             }
@@ -249,7 +249,7 @@ impl Instance {
             // doubtful there's a place on earth that gets that low.
 
             if (0.0..=100.0).contains(&humidity) {
-                (self.d_humidity)(humidity.into()).await
+                (self.d_humidity)(humidity).await
             } else {
                 warn!("ignoring bad humidity value: {:.1}", humidity)
             }
@@ -258,7 +258,7 @@ impl Instance {
         // If UV readings are provided, report them.
 
         if let Some(uv) = obs.uv {
-            (self.d_uv)(uv.into()).await
+            (self.d_uv)(uv).await
         }
 
         // If wind direction readings are provided, report them.
@@ -267,7 +267,7 @@ impl Instance {
             // Make sure the reading is in range.
 
             if (0.0..=360.0).contains(&winddir) {
-                (self.d_wnddir)(winddir.into()).await
+                (self.d_wnddir)(winddir).await
             } else {
                 warn!("ignoring bad wind direction value: {:.1}", winddir)
             }
@@ -486,7 +486,7 @@ impl driver::API for Instance {
                                         if obs.len() > 1 {
                                             warn!("ignoring {} extra weather observations", obs.len() - 1);
                                         }
-                                        (self.d_state)(true.into()).await;
+                                        (self.d_state)(true).await;
                                         self.handle(&obs[0]).await;
                                         continue;
                                     }
@@ -495,19 +495,19 @@ impl driver::API for Instance {
                             }
 
                             Err(e) => {
-                                (self.d_state)(false.into()).await;
+                                (self.d_state)(false).await;
                                 panic!("error response from Weather Underground -- {:?}", &e)
                             }
                         }
                     }
 
                     Ok(None) => {
-                        (self.d_state)(false.into()).await;
+                        (self.d_state)(false).await;
                         panic!("no response from Weather Underground")
                     }
 
                     Err(e) => {
-                        (self.d_state)(false.into()).await;
+                        (self.d_state)(false).await;
                         panic!(
                             "error accessing Weather Underground -- {:?}",
                             &e

--- a/drivers/drmem-drv-weather-wu/src/lib.rs
+++ b/drivers/drmem-drv-weather-wu/src/lib.rs
@@ -1,6 +1,6 @@
 use drmem_api::{
     driver::{self, DriverConfig},
-    types::{device::Base, Error},
+    types::{device, Error},
     Result,
 };
 use std::convert::{Infallible, TryFrom};
@@ -22,20 +22,20 @@ pub struct Instance {
     precip_int: f64,
     prev_precip_total: Option<f64>,
 
-    d_dewpt: driver::ReportReading,
-    d_htidx: driver::ReportReading,
-    d_humidity: driver::ReportReading,
-    d_prate: driver::ReportReading,
-    d_ptotal: driver::ReportReading,
-    d_pressure: driver::ReportReading,
-    d_solrad: driver::ReportReading,
-    d_state: driver::ReportReading,
-    d_temp: driver::ReportReading,
-    d_uv: driver::ReportReading,
-    d_wndchl: driver::ReportReading,
-    d_wnddir: driver::ReportReading,
-    d_wndgst: driver::ReportReading,
-    d_wndspd: driver::ReportReading,
+    d_dewpt: driver::ReportReading<device::Value>,
+    d_htidx: driver::ReportReading<device::Value>,
+    d_humidity: driver::ReportReading<device::Value>,
+    d_prate: driver::ReportReading<device::Value>,
+    d_ptotal: driver::ReportReading<device::Value>,
+    d_pressure: driver::ReportReading<device::Value>,
+    d_solrad: driver::ReportReading<device::Value>,
+    d_state: driver::ReportReading<device::Value>,
+    d_temp: driver::ReportReading<device::Value>,
+    d_uv: driver::ReportReading<device::Value>,
+    d_wndchl: driver::ReportReading<device::Value>,
+    d_wnddir: driver::ReportReading<device::Value>,
+    d_wndgst: driver::ReportReading<device::Value>,
+    d_wndspd: driver::ReportReading<device::Value>,
 }
 
 impl Instance {
@@ -282,20 +282,20 @@ impl driver::API for Instance {
     ) -> Pin<
         Box<dyn Future<Output = Result<driver::DriverType>> + Send + 'static>,
     > {
-        let dewpoint_name = "dewpoint".parse::<Base>().unwrap();
-        let heat_index_name = "heat-index".parse::<Base>().unwrap();
-        let humidity_name = "humidity".parse::<Base>().unwrap();
-        let precip_rate_name = "precip-rate".parse::<Base>().unwrap();
-        let precip_total_name = "precip-total".parse::<Base>().unwrap();
-        let pressure_name = "pressure".parse::<Base>().unwrap();
-        let solar_rad_name = "solar-rad".parse::<Base>().unwrap();
-        let state_name = "state".parse::<Base>().unwrap();
-        let temperature_name = "temperature".parse::<Base>().unwrap();
-        let uv_name = "uv".parse::<Base>().unwrap();
-        let wind_chill_name = "wind-chill".parse::<Base>().unwrap();
-        let wind_dir_name = "wind-dir".parse::<Base>().unwrap();
-        let wind_gust_name = "wind-gust".parse::<Base>().unwrap();
-        let wind_speed_name = "wind-speed".parse::<Base>().unwrap();
+        let dewpoint_name = "dewpoint".parse::<device::Base>().unwrap();
+        let heat_index_name = "heat-index".parse::<device::Base>().unwrap();
+        let humidity_name = "humidity".parse::<device::Base>().unwrap();
+        let precip_rate_name = "precip-rate".parse::<device::Base>().unwrap();
+        let precip_total_name = "precip-total".parse::<device::Base>().unwrap();
+        let pressure_name = "pressure".parse::<device::Base>().unwrap();
+        let solar_rad_name = "solar-rad".parse::<device::Base>().unwrap();
+        let state_name = "state".parse::<device::Base>().unwrap();
+        let temperature_name = "temperature".parse::<device::Base>().unwrap();
+        let uv_name = "uv".parse::<device::Base>().unwrap();
+        let wind_chill_name = "wind-chill".parse::<device::Base>().unwrap();
+        let wind_dir_name = "wind-dir".parse::<device::Base>().unwrap();
+        let wind_gust_name = "wind-gust".parse::<device::Base>().unwrap();
+        let wind_speed_name = "wind-speed".parse::<device::Base>().unwrap();
 
         let fut = async move {
             match wu::create_client(Duration::from_secs(5)) {

--- a/drmem-api/src/driver.rs
+++ b/drmem-api/src/driver.rs
@@ -43,12 +43,8 @@ pub type SettingStream<T> =
     Pin<Box<dyn Stream<Item = (T, SettingReply<T>)> + Send>>;
 
 /// A function that drivers use to report updated values of a device.
-pub type ReportReading<T> = Box<
-    dyn Fn(T) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
-        + Send
-        + Sync
-        + 'static,
->;
+pub type ReportReading<T> =
+    Box<dyn Fn(T) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 /// Defines the requests that can be sent to core. Drivers don't use
 /// this type directly. They are indirectly used by `RequestChan`.

--- a/drmem-api/src/lib.rs
+++ b/drmem-api/src/lib.rs
@@ -44,7 +44,10 @@ pub trait Store {
     async fn register_read_only_device(
         &mut self, driver: &str, name: &types::device::Name,
         units: &Option<String>, max_history: &Option<usize>,
-    ) -> Result<(driver::ReportReading, Option<types::device::Value>)>;
+    ) -> Result<(
+        driver::ReportReading<types::device::Value>,
+        Option<types::device::Value>,
+    )>;
 
     /// Called when a read-write device is to be registered with the
     /// back-end.
@@ -73,7 +76,7 @@ pub trait Store {
         &mut self, driver: &str, name: &types::device::Name,
         units: &Option<String>, max_history: &Option<usize>,
     ) -> Result<(
-        driver::ReportReading,
+        driver::ReportReading<types::device::Value>,
         driver::RxDeviceSetting,
         Option<types::device::Value>,
     )>;

--- a/drmemd/src/driver/drv_cycle.rs
+++ b/drmemd/src/driver/drv_cycle.rs
@@ -25,8 +25,8 @@ pub struct Instance {
     enabled_at_boot: bool,
     state: CycleState,
     millis: time::Duration,
-    d_output: driver::ReportReading,
-    d_enable: driver::ReportReading,
+    d_output: driver::ReportReading<device::Value>,
+    d_enable: driver::ReportReading<device::Value>,
     s_enable: driver::RxDeviceSetting,
 }
 
@@ -41,8 +41,10 @@ impl Instance {
     /// Creates a new, idle `Instance`.
 
     pub fn new(
-        enabled: bool, millis: time::Duration, d_output: driver::ReportReading,
-        d_enable: driver::ReportReading, s_enable: driver::RxDeviceSetting,
+        enabled: bool, millis: time::Duration,
+        d_output: driver::ReportReading<device::Value>,
+        d_enable: driver::ReportReading<device::Value>,
+        s_enable: driver::RxDeviceSetting,
     ) -> Instance {
         Instance {
             enabled_at_boot: enabled,

--- a/drmemd/src/driver/drv_memory.rs
+++ b/drmemd/src/driver/drv_memory.rs
@@ -1,13 +1,13 @@
 use drmem_api::{
     driver::{self, DriverConfig},
-    types::{device::Base, Error},
+    types::{device, Error},
     Result,
 };
 use std::{convert::Infallible, future::Future, pin::Pin};
 use tracing::{self, error};
 
 pub struct Instance {
-    d_memory: driver::ReportReading,
+    d_memory: driver::ReportReading<device::Value>,
     s_memory: driver::RxDeviceSetting,
 }
 
@@ -21,17 +21,18 @@ impl Instance {
     /// Creates a new `Instance` instance.
 
     pub fn new(
-        d_memory: driver::ReportReading, s_memory: driver::RxDeviceSetting,
+        d_memory: driver::ReportReading<device::Value>,
+        s_memory: driver::RxDeviceSetting,
     ) -> Instance {
         Instance { d_memory, s_memory }
     }
 
     // Gets the name of the device from the configuration.
 
-    fn get_cfg_name(cfg: &DriverConfig) -> Result<Base> {
+    fn get_cfg_name(cfg: &DriverConfig) -> Result<device::Base> {
         match cfg.get("name") {
             Some(toml::value::Value::String(name)) => {
-                if let Ok(name) = name.parse::<Base>() {
+                if let Ok(name) = name.parse::<device::Base>() {
                     return Ok(name);
                 } else {
                     error!("'name' isn't a proper, base name for a device")

--- a/drmemd/src/driver/drv_timer.rs
+++ b/drmemd/src/driver/drv_timer.rs
@@ -26,8 +26,8 @@ pub struct Instance {
     state: TimerState,
     active_level: bool,
     millis: time::Duration,
-    d_output: driver::ReportReading,
-    d_enable: driver::ReportReading,
+    d_output: driver::ReportReading<device::Value>,
+    d_enable: driver::ReportReading<device::Value>,
     s_enable: driver::RxDeviceSetting,
 }
 
@@ -44,7 +44,8 @@ impl Instance {
 
     pub fn new(
         active_level: bool, millis: time::Duration,
-        d_output: driver::ReportReading, d_enable: driver::ReportReading,
+        d_output: driver::ReportReading<device::Value>,
+        d_enable: driver::ReportReading<device::Value>,
         s_enable: driver::RxDeviceSetting,
     ) -> Instance {
         Instance {

--- a/drmemd/src/driver/drv_timer.rs
+++ b/drmemd/src/driver/drv_timer.rs
@@ -1,14 +1,12 @@
 use drmem_api::{
     driver::{self, DriverConfig},
-    types::{
-        device::{self, Base},
-        Error,
-    },
+    types::{device::Base, Error},
     Result,
 };
 use std::{convert::Infallible, future::Future, pin::Pin};
 use tokio::time;
-use tracing::{self, debug, error, info, warn};
+use tokio_stream::StreamExt;
+use tracing::{self, debug, error, info};
 
 // This enum represents the four states in which the timer can
 // be. They are a combination of the `enable` input and whether we're
@@ -28,7 +26,7 @@ pub struct Instance {
     millis: time::Duration,
     d_output: driver::ReportReading<bool>,
     d_enable: driver::ReportReading<bool>,
-    s_enable: driver::RxDeviceSetting,
+    s_enable: driver::SettingStream<bool>,
 }
 
 impl Instance {
@@ -46,7 +44,7 @@ impl Instance {
         active_level: bool, millis: time::Duration,
         d_output: driver::ReportReading<bool>,
         d_enable: driver::ReportReading<bool>,
-        s_enable: driver::RxDeviceSetting,
+        s_enable: driver::SettingStream<bool>,
     ) -> Instance {
         Instance {
             state: TimerState::Armed,
@@ -251,34 +249,22 @@ impl driver::API for Instance {
                     // handle is saved in the device look-up
                     // table. All other handles are cloned from it.
 
-                    Some((v, tx)) = self.s_enable.recv() => {
+                    Some((b, reply)) = self.s_enable.next() => {
+                        let (out, tmo) = self.update_state(b);
 
-			// If a client sends us something besides a
-			// boolean, return an error and ignore the
-			// setting. Otherwise, echo the value back to
-			// the client and update the state with the
-			// new value.
+                        reply(Ok(b));
 
-			if let device::Value::Bool(b) = v {
-                            let (out, tmo) = self.update_state(b);
-                            let _ = tx.send(Ok(v));
+                        debug!("state {:?} : new input -> {}", &self.state, b);
 
-                            debug!("state {:?} : new input -> {}", &self.state, b);
+                        if let Some(tmo) = tmo {
+			    timeout = tmo
+                        }
 
-                            if let Some(tmo) = tmo {
-				timeout = tmo
-                            }
+                        (self.d_enable)(b).await;
 
-                            (self.d_enable)(b).await;
-
-                            if let Some(out) = out {
-				(self.d_output)(out).await;
-                            }
-			} else {
-                            let _ = tx.send(Err(Error::TypeError));
-
-                            warn!("state {:?} : received bad value -> {:?}", &self.state, &v);
-			}
+                        if let Some(out) = out {
+			    (self.d_output)(out).await;
+                        }
                     }
                 }
             }
@@ -291,7 +277,7 @@ impl driver::API for Instance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::{sync::mpsc, time};
+    use tokio::time;
 
     fn fake_report(_v: bool) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         Box::pin(async { () })
@@ -299,7 +285,7 @@ mod tests {
 
     #[test]
     fn test_state_changes() {
-        let (_tx, rx) = mpsc::channel(20);
+        let rx: driver::SettingStream<bool> = Box::pin(tokio_stream::empty());
         let mut timer = Instance::new(
             true,
             time::Duration::from_millis(1000),


### PR DESCRIPTION
At the moment, I'm working on phase 1 of the issue which adds some type-safety to the driver's API. Drivers need to report values and receive values (for settable devices.) This requires changes in 3 types:

- The `ReportReading` closure now takes a type parameter. When registering a device, its type is also declared. No longer can one accidentally save a `String` for a `bool` device.
- When registering, the previous value (if any) of the device is returned. This value needs to be converted to the device's type (instead of just being a `device::Value`.
- Incoming settings need to convert `device::Value` types to the device's declared type. If it can't, the API should automatically send a `TypeError` back to the client.

At this point, I've pushed commits which support the first two requirements. I'm still working on the third.

This pull request will close out #13.