### PR TITLE
:recycle: add type information

### DIFF
--- a/backends/drmem-db-simple/src/lib.rs
+++ b/backends/drmem-db-simple/src/lib.rs
@@ -406,16 +406,15 @@ impl Store for SimpleStore {
                         }
                     }
                     (Some(start_tmp), Some(end_tmp)) => {
-
-			// Make sure the `start` time is before the
-			// `end` time.
+                        // Make sure the `start` time is before the
+                        // `end` time.
 
                         let start: time::SystemTime =
                             std::cmp::min(start_tmp, end_tmp);
                         let end: time::SystemTime =
                             std::cmp::max(start_tmp, end_tmp);
 
-			// Define predicates for filters.
+                        // Define predicates for filters.
 
                         let valid = move |v: &device::Reading| v.ts >= start;
                         let not_end = move |v: &device::Reading| v.ts <= end;

--- a/backends/drmem-db-simple/src/lib.rs
+++ b/backends/drmem-db-simple/src/lib.rs
@@ -406,8 +406,17 @@ impl Store for SimpleStore {
                         }
                     }
                     (Some(start_tmp), Some(end_tmp)) => {
-                        let start = std::cmp::min(start_tmp, end_tmp);
-                        let end = std::cmp::max(start_tmp, end_tmp);
+
+			// Make sure the `start` time is before the
+			// `end` time.
+
+                        let start: time::SystemTime =
+                            std::cmp::min(start_tmp, end_tmp);
+                        let end: time::SystemTime =
+                            std::cmp::max(start_tmp, end_tmp);
+
+			// Define predicates for filters.
+
                         let valid = move |v: &device::Reading| v.ts >= start;
                         let not_end = move |v: &device::Reading| v.ts <= end;
 


### PR DESCRIPTION
One GitHub configuration was having a hard time determining the types for these variables. This commit should prevent the error from happening.