### PR TITLE
:arrow_up: update `toml` crate to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1"
 
 futures = { version = "0.3", features = ["std"] }
 
-toml = "0.5"
+toml = "0.7"
 chrono = "0.4"
 
 tokio = { version = "1", features = ["macros", "time", "sync"] }

--- a/drmem-api/src/types/device/name.rs
+++ b/drmem-api/src/types/device/name.rs
@@ -69,7 +69,7 @@ impl fmt::Display for Segment {
 /// A path is a series of segments, where segments are made up of one
 /// or more alphanumeric or dash characters.
 #[derive(Debug, PartialEq, Clone, Deserialize, Hash, Eq)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 pub struct Path(Vec<Segment>);
 
 impl Path {
@@ -88,11 +88,11 @@ impl Path {
 // notation for the path specification (because `Path` is a newtype
 // that wraps a `Vec<>`.)
 
-impl TryFrom<&str> for Path {
+impl TryFrom<String> for Path {
     type Error = Error;
 
-    fn try_from(s: &str) -> Result<Self> {
-        Path::create(s)
+    fn try_from(s: String) -> Result<Self> {
+        Path::create(&s)
     }
 }
 
@@ -121,7 +121,7 @@ impl fmt::Display for Path {
 /// The base name consists of one or more alphanumeric or dash
 /// characters.
 #[derive(Debug, PartialEq, Clone, Deserialize, Hash, Eq)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 pub struct Base(Segment);
 
 impl Base {
@@ -132,11 +132,11 @@ impl Base {
     }
 }
 
-impl TryFrom<&str> for Base {
+impl TryFrom<String> for Base {
     type Error = Error;
 
-    fn try_from(s: &str) -> Result<Self> {
-        Base::create(s)
+    fn try_from(s: String) -> Result<Self> {
+        Base::create(&s)
     }
 }
 
@@ -179,7 +179,7 @@ impl fmt::Display for Base {
 /// a logical path hierarchy can make those searches more productive.
 
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Deserialize)]
-#[serde(try_from = "&str")]
+#[serde(try_from = "String")]
 pub struct Name {
     path: Path,
     base: Base,
@@ -231,11 +231,11 @@ impl fmt::Display for Name {
     }
 }
 
-impl TryFrom<&str> for Name {
+impl TryFrom<String> for Name {
     type Error = Error;
 
-    fn try_from(s: &str) -> Result<Self> {
-        Name::create(s)
+    fn try_from(s: String) -> Result<Self> {
+        Name::create(&s)
     }
 }
 


### PR DESCRIPTION
This required some changes since the TOML library no longer likes to keep references to the text.