### PR TITLE
:bug: driver wasn't detecting a stale TCP connection

### DIFF
--- a/drivers/drmem-drv-sump/Cargo.toml
+++ b/drivers/drmem-drv-sump/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["control-system", "automation"]
 doctest = false
 
 [dependencies]
+socket2 = "0.5"
+
 toml.workspace = true
 
 tokio = { workspace = true, features = ["net", "io-util"] }

--- a/drivers/drmem-drv-sump/src/lib.rs
+++ b/drivers/drmem-drv-sump/src/lib.rs
@@ -227,13 +227,16 @@ impl Instance {
     }
 
     fn connect(addr: &SocketAddrV4) -> Result<TcpStream> {
-        use socket2::{Domain, Socket, Type};
+        use socket2::{Domain, Socket, TcpKeepalive, Type};
 
+        let keepalive = TcpKeepalive::new()
+            .with_time(time::Duration::from_secs(5))
+            .with_interval(time::Duration::from_secs(5));
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None)
             .expect("couldn't create socket");
 
         socket
-            .set_keepalive(true)
+            .set_tcp_keepalive(&keepalive)
             .expect("couldn't enable keep-alive on sump socket");
 
         info!("connecting to {}", addr);


### PR DESCRIPTION
This driver was using `tokio::net::TcpStream` to connect to the RPi that was monitoring the sump pump. If that connection broke (due to a power outage, for instance), the driver would wait forever and would never get any data from the remote end.

This commit pulls in the `socket2` crate so that we can turn on the "keep-alive" option for the socket (`tokio` doesn't provide this option.)

Note that we use the `socket2` crate's API to build, configure, and connect the socket before converting it to a `tokio` socket. The `socket2` API is synchronous so, for connecting, I set the timeout to 0.1 seconds. This is more than enough time to connect and it minimizes the amount of time taken away from other async tasks.