### PR TITLE
:bug: fix dependencies

### DIFF
--- a/drivers/drmem-drv-tplink/Cargo.toml
+++ b/drivers/drmem-drv-tplink/Cargo.toml
@@ -17,12 +17,12 @@ doctest = false
 toml.workspace = true
 
 futures.workspace = true
-tokio = { workspace = true, features = ["net", "macros"] }
+tokio = { workspace = true, features = ["net", "time", "macros", "io-util"] }
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_derive.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["std"] }
 
 drmem-api = { path = "../../drmem-api", version = "0.3.1" }


### PR DESCRIPTION
The TP-Link driver would compile fine when building `drmemd`. However, when trying to publish it to crates.io, it would fail. This commit enables the features that the driver requires.