### PR TITLE
Add time-of-day driver

### DIFF
--- a/drmemd/Cargo.toml
+++ b/drmemd/Cargo.toml
@@ -34,7 +34,7 @@ serde_derive.workspace = true
 
 clap = { version = "4", features = ["cargo"] }
 
-chrono.workspace = true
+chrono = { workspace = true, features = ["clock"] }
 
 lazy_static = "1"
 

--- a/drmemd/Cargo.toml
+++ b/drmemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drmemd"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Rich Neswold <rich.neswold@gmail.com>"]
 edition = "2021"
 description = "Main process of the DrMem control system"
@@ -77,7 +77,7 @@ optional = true
 
 [dependencies.drmem-db-simple]
 path = "../backends/drmem-db-simple"
-version = "0.3"
+version = "0.3.1"
 optional = true
 
 # This section defines the optional dependencies for the 'graphql'

--- a/drmemd/src/driver/drv_tod.md
+++ b/drmemd/src/driver/drv_tod.md
@@ -1,8 +1,8 @@
-# drmem-drv-timer
+# drmem-drv-tod
 
-Provides devices that implement a timer interface. Anytime the
-`enable` device transitions from `false` to `true`, the output stays
-active for a configured amount of time.
+Provides devices that indicate the time-of-day. The driver can be
+configured to generate UTC values or values based on the local
+timezone.
 
 This driver is always available in DrMem.
 
@@ -10,31 +10,24 @@ This driver is always available in DrMem.
 
 This driver uses the following configuration parameters.
 
-- `active_level` is a boolean which defines the output value when the
-  timer is active. Once the timer expires, the output will be set to
-  the complement of this.
-- `millis` is the number of milliseconds the timer will remain
-  active. NOTE: Officially, DrMem uses 20 Hz (50 ms) as it's fastest
-  response time. Although you could specify a shorter time, you might
-  be disappointed in its accuracy (depending on your system hardware
-  and its CPU load.)
+- `utc` is a boolean which, when `true`, means the devices will
+  represent UTC time. If `false`, the devices will represent local
+  time.
 
 ## Devices
 
 The driver creates these devices:
 
-| Base Name | Type     | Units | Comment                                                        |
-|-----------|----------|-------|----------------------------------------------------------------|
-| `enable`  | bool, RW |       | A `false` to `true` transition will reset and start the timer. |
-| `output`  | bool, RO |       | Output state of timer.                                         |
-
-Every value sent to the `enable` device will be reported -- even
-duplicates. This allows one to, if using the redis backend, see the
-history of settings made to the device. The `output` device, however,
-only reports state changes. So if a client were to start the timer and
-start it again before it expires, the `output` would only report the
-initial active and then the final inactive values.
+| Base Name     | Type    | Units | Comment                         |
+|---------------|---------|-------|---------------------------------|
+| `year`        | int, R0 |       | The year portion of the date.   |
+| `month`       | int, R0 |       | The month portion of the date, ranging from 0 to 11. |
+| `day`         | int, R0 |       | The day of the month portion of the date, ranging from 0 to 30. |
+| `day-of-week` | int, R0 |       | The day of the week portion of the date, ranges from 0 to 6. 0 is Monday and 6 is Sunday. |
+| `hour`        | int, R0 |       | The hour portion of the date. Ranges from 0 to 23. |
+| `minute`      | int, R0 |       | The minute portion of the date. |
+| `second`      | int, R0 |       | The second portion of the date. |
 
 ## History
 
-Added in v0.1.0.
+Added in v0.3.1.

--- a/drmemd/src/driver/drv_tod.md
+++ b/drmemd/src/driver/drv_tod.md
@@ -1,0 +1,40 @@
+# drmem-drv-timer
+
+Provides devices that implement a timer interface. Anytime the
+`enable` device transitions from `false` to `true`, the output stays
+active for a configured amount of time.
+
+This driver is always available in DrMem.
+
+## Configuration
+
+This driver uses the following configuration parameters.
+
+- `active_level` is a boolean which defines the output value when the
+  timer is active. Once the timer expires, the output will be set to
+  the complement of this.
+- `millis` is the number of milliseconds the timer will remain
+  active. NOTE: Officially, DrMem uses 20 Hz (50 ms) as it's fastest
+  response time. Although you could specify a shorter time, you might
+  be disappointed in its accuracy (depending on your system hardware
+  and its CPU load.)
+
+## Devices
+
+The driver creates these devices:
+
+| Base Name | Type     | Units | Comment                                                        |
+|-----------|----------|-------|----------------------------------------------------------------|
+| `enable`  | bool, RW |       | A `false` to `true` transition will reset and start the timer. |
+| `output`  | bool, RO |       | Output state of timer.                                         |
+
+Every value sent to the `enable` device will be reported -- even
+duplicates. This allows one to, if using the redis backend, see the
+history of settings made to the device. The `output` device, however,
+only reports state changes. So if a client were to start the timer and
+start it again before it expires, the `output` would only report the
+initial active and then the final inactive values.
+
+## History
+
+Added in v0.1.0.

--- a/drmemd/src/driver/drv_tod.rs
+++ b/drmemd/src/driver/drv_tod.rs
@@ -41,7 +41,7 @@ impl driver::API for Instance {
     fn register_devices(
         core: driver::RequestChan,
         _cfg: &DriverConfig,
-        max_history: Option<usize>,
+        _max_history: Option<usize>,
     ) -> Pin<Box<dyn Future<Output = Result<Self::DeviceSet>> + Send>> {
         let year_name = "year".parse::<device::Base>().unwrap();
         let month_name = "month".parse::<device::Base>().unwrap();
@@ -53,19 +53,19 @@ impl driver::API for Instance {
 
         Box::pin(async move {
             let (d_year, _) =
-                core.add_ro_device(year_name, None, max_history).await?;
+                core.add_ro_device(year_name, None, Some(1)).await?;
             let (d_month, _) =
-                core.add_ro_device(month_name, None, max_history).await?;
+                core.add_ro_device(month_name, None, Some(1)).await?;
             let (d_day, _) =
-                core.add_ro_device(day_name, None, max_history).await?;
+                core.add_ro_device(day_name, None, Some(1)).await?;
             let (d_hour, _) =
-                core.add_ro_device(hour_name, None, max_history).await?;
+                core.add_ro_device(hour_name, None, Some(1)).await?;
             let (d_min, _) =
-                core.add_ro_device(min_name, None, max_history).await?;
+                core.add_ro_device(min_name, None, Some(1)).await?;
             let (d_second, _) =
-                core.add_ro_device(second_name, None, max_history).await?;
+                core.add_ro_device(second_name, None, Some(1)).await?;
             let (d_dow, _) =
-                core.add_ro_device(dow_name, None, max_history).await?;
+                core.add_ro_device(dow_name, None, Some(1)).await?;
 
             Ok(Devices {
                 d_year,

--- a/drmemd/src/driver/drv_tod.rs
+++ b/drmemd/src/driver/drv_tod.rs
@@ -1,0 +1,170 @@
+use chrono::{self, Datelike, Timelike};
+use drmem_api::{
+    device,
+    driver::{self, DriverConfig},
+    Error, Result,
+};
+use std::{convert::Infallible, future::Future, pin::Pin, sync::Arc};
+use tokio::{sync::Mutex, time};
+
+pub struct Instance;
+
+pub struct Devices {
+    d_year: driver::ReportReading<u16>,
+    d_month: driver::ReportReading<u16>,
+    d_day: driver::ReportReading<u16>,
+    d_hour: driver::ReportReading<u16>,
+    d_min: driver::ReportReading<u16>,
+    d_second: driver::ReportReading<u16>,
+    d_dow: driver::ReportReading<u16>,
+}
+
+impl Instance {
+    pub const NAME: &'static str = "tod";
+
+    pub const SUMMARY: &'static str =
+        "Provides devices that represent time-of-day.";
+
+    pub const DESCRIPTION: &'static str = include_str!("drv_tod.md");
+
+    pub fn initial_delay() -> u32 {
+        let now = chrono::Utc::now();
+        let extra = now.timestamp_subsec_millis();
+
+        (10020 - extra) % 1000
+    }
+}
+
+impl driver::API for Instance {
+    type DeviceSet = Devices;
+
+    fn register_devices(
+        core: driver::RequestChan,
+        _cfg: &DriverConfig,
+        max_history: Option<usize>,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::DeviceSet>> + Send>> {
+        let year_name = "year".parse::<device::Base>().unwrap();
+        let month_name = "month".parse::<device::Base>().unwrap();
+        let day_name = "day".parse::<device::Base>().unwrap();
+        let hour_name = "hour".parse::<device::Base>().unwrap();
+        let min_name = "minute".parse::<device::Base>().unwrap();
+        let second_name = "second".parse::<device::Base>().unwrap();
+        let dow_name = "day-of-week".parse::<device::Base>().unwrap();
+
+        Box::pin(async move {
+            let (d_year, _) =
+                core.add_ro_device(year_name, None, max_history).await?;
+            let (d_month, _) =
+                core.add_ro_device(month_name, None, max_history).await?;
+            let (d_day, _) =
+                core.add_ro_device(day_name, None, max_history).await?;
+            let (d_hour, _) =
+                core.add_ro_device(hour_name, None, max_history).await?;
+            let (d_min, _) =
+                core.add_ro_device(min_name, None, max_history).await?;
+            let (d_second, _) =
+                core.add_ro_device(second_name, None, max_history).await?;
+            let (d_dow, _) =
+                core.add_ro_device(dow_name, None, max_history).await?;
+
+            Ok(Devices {
+                d_year,
+                d_month,
+                d_day,
+                d_hour,
+                d_min,
+                d_second,
+                d_dow,
+            })
+        })
+    }
+
+    fn create_instance(
+        _cfg: &DriverConfig,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<Self>>> + Send>> {
+        Box::pin(async move { Ok(Box::new(Instance)) })
+    }
+
+    fn run<'a>(
+        &'a mut self,
+        devices: Arc<Mutex<Self::DeviceSet>>,
+    ) -> Pin<Box<dyn Future<Output = Infallible> + Send + 'a>> {
+        let fut = async move {
+            let mut year: Option<u16> = None;
+            let mut month: Option<u16> = None;
+            let mut day: Option<u16> = None;
+            let mut hour: Option<u16> = None;
+            let mut minute: Option<u16> = None;
+            let mut second: Option<u16> = None;
+            let mut dow: Option<u16> = None;
+
+            let mut interval = time::interval_at(
+                time::Instant::now()
+                    + time::Duration::from_millis(
+                        Instance::initial_delay() as u64
+                    ),
+                time::Duration::from_secs(1),
+            );
+
+            let devices = devices.lock().await;
+
+            loop {
+                let _inst = interval.tick().await;
+
+                let now = chrono::Utc::now().naive_utc();
+
+                let now_year = now.year() as u16;
+                let now_month = now.month0() as u16;
+                let now_day = now.day0() as u16;
+                let now_dow = now.weekday().num_days_from_monday() as u16;
+
+                let now_hour = now.hour() as u16;
+                let now_min = now.minute() as u16;
+                let now_sec = now.second() as u16;
+
+                if year != Some(now_year) {
+                    year = Some(now_year);
+                    (devices.d_year)(now_year).await
+                }
+
+                if month != Some(now_month) {
+                    month = Some(now_month);
+                    (devices.d_month)(now_month).await
+                }
+
+                if day != Some(now_day) {
+                    day = Some(now_day);
+                    (devices.d_day)(now_day).await
+                }
+
+                if hour != Some(now_hour) {
+                    hour = Some(now_hour);
+                    (devices.d_hour)(now_hour).await
+                }
+
+                if minute != Some(now_min) {
+                    minute = Some(now_min);
+                    (devices.d_min)(now_min).await
+                }
+
+                if second != Some(now_sec) {
+                    second = Some(now_sec);
+                    (devices.d_second)(now_sec).await
+                }
+
+                if dow != Some(now_dow) {
+                    dow = Some(now_dow);
+                    (devices.d_dow)(now_dow).await
+                }
+            }
+        };
+
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_tod() {}
+}

--- a/drmemd/src/driver/mod.rs
+++ b/drmemd/src/driver/mod.rs
@@ -9,6 +9,7 @@ use tracing_futures::Instrument;
 mod drv_cycle;
 mod drv_memory;
 mod drv_timer;
+mod drv_tod;
 
 pub type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 pub type MgrTask = Fut<Infallible>;
@@ -172,6 +173,19 @@ impl DriverDb {
 
         {
             use drv_cycle::Instance;
+
+            table.insert(
+                Instance::NAME,
+                (
+                    Instance::SUMMARY,
+                    Instance::DESCRIPTION,
+                    manage_instance::<Instance>,
+                ),
+            );
+        }
+
+        {
+            use drv_tod::Instance;
 
             table.insert(
                 Instance::NAME,


### PR DESCRIPTION
This pull request adds a time-of-day driver to DrMem. This is an internal driver for `drmemd` so it's always available.