### PR TITLE
Fix regression in TP-Link driver

### DIFF
--- a/drivers/drmem-drv-tplink/Cargo.toml
+++ b/drivers/drmem-drv-tplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drmem-drv-tplink"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rich Neswold <rich.neswold@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/DrMemCS/drmem"

--- a/drivers/drmem-drv-tplink/src/lib.rs
+++ b/drivers/drmem-drv-tplink/src/lib.rs
@@ -410,7 +410,6 @@ impl Instance {
 
         s.write_all(&out_buf[..])
             .await
-            .map(|_| ())
             .map_err(|e| Error::MissingPeer(e.to_string()))?;
         s.flush()
             .await

--- a/drivers/drmem-drv-tplink/src/lib.rs
+++ b/drivers/drmem-drv-tplink/src/lib.rs
@@ -416,11 +416,13 @@ impl Instance {
             .map_err(|e| Error::MissingPeer(e.to_string()))
     }
 
-    async fn main_loop<'a>(
+    async fn main_loop<'a, T>(
         &mut self,
-        s: &mut TcpStream,
+        s: &mut T,
         devices: &mut MutexGuard<'_, Devices>,
-    ) {
+    ) where
+        T: AsyncReadExt + AsyncWriteExt + std::marker::Unpin,
+    {
         // Create a 5-second interval timer which will be used to poll
         // the device to see if its state was changed by some outside
         // mechanism.

--- a/drivers/drmem-drv-tplink/src/lib.rs
+++ b/drivers/drmem-drv-tplink/src/lib.rs
@@ -343,8 +343,8 @@ impl Instance {
 
     async fn read_reply(s: &mut TcpStream) -> Result<tplink_api::Reply> {
         if let Ok(sz) = s.read_u32().await {
-            let mut buf = Vec::with_capacity(sz as usize);
-            let filled = &mut buf[..];
+            let mut buf = [0; 1_000];
+            let filled = &mut buf[0..sz as usize];
 
             if let Err(e) = s.read_exact(filled).await {
                 Err(Error::MissingPeer(e.to_string()))

--- a/drivers/drmem-drv-tplink/src/lib.rs
+++ b/drivers/drmem-drv-tplink/src/lib.rs
@@ -345,30 +345,30 @@ impl Instance {
     where
         R: AsyncReadExt + std::marker::Unpin,
     {
-	const RCV_TOTAL: usize = 1_000;
+        const RCV_TOTAL: usize = 1_000;
 
         if let Ok(sz) = s.read_u32().await {
-	    let sz = sz as usize;
+            let sz = sz as usize;
 
-	    if sz <= RCV_TOTAL {
-		let mut buf = [0u8; RCV_TOTAL];
-		let filled = &mut buf[0..sz as usize];
+            if sz <= RCV_TOTAL {
+                let mut buf = [0u8; RCV_TOTAL];
+                let filled = &mut buf[0..sz as usize];
 
-		if let Err(e) = s.read_exact(filled).await {
+                if let Err(e) = s.read_exact(filled).await {
                     Err(Error::MissingPeer(e.to_string()))
-		} else {
+                } else {
                     tplink_api::Reply::decode(filled).ok_or_else(|| {
-			Error::ParseError(format!(
+                        Error::ParseError(format!(
                             "bad reply : {}",
                             String::from_utf8_lossy(filled)
-			))
+                        ))
                     })
-		}
-	    } else {
+                }
+            } else {
                 Err(Error::ParseError(format!(
-		    "reply size ({sz}) is greater than {RCV_TOTAL}"
+                    "reply size ({sz}) is greater than {RCV_TOTAL}"
                 )))
-	    }
+            }
         } else {
             Err(Error::MissingPeer("error reading header".into()))
         }
@@ -633,32 +633,32 @@ mod test {
 
     #[tokio::test]
     async fn test_read_reply() {
-	// Make sure packets with less than 4 bytes causes an error.
+        // Make sure packets with less than 4 bytes causes an error.
 
-	{
-	    let buf: &[u8] = &[0, 0, 0];
+        {
+            let buf: &[u8] = &[0, 0, 0];
 
-	    assert!(Instance::read_reply(&mut &buf[0..=0]).await.is_err());
-	    assert!(Instance::read_reply(&mut &buf[0..1]).await.is_err());
-	    assert!(Instance::read_reply(&mut &buf[0..2]).await.is_err());
-	    assert!(Instance::read_reply(&mut &buf[0..3]).await.is_err());
-	}
+            assert!(Instance::read_reply(&mut &buf[0..=0]).await.is_err());
+            assert!(Instance::read_reply(&mut &buf[0..1]).await.is_err());
+            assert!(Instance::read_reply(&mut &buf[0..2]).await.is_err());
+            assert!(Instance::read_reply(&mut &buf[0..3]).await.is_err());
+        }
 
-	{
-	    const REPLY: &[u8] =
-		b"{\"system\":{\"set_led_off\":{\"err_code\":0}}}";
+        {
+            const REPLY: &[u8] =
+                b"{\"system\":{\"set_led_off\":{\"err_code\":0}}}";
 
-	    let mut buf = vec![0, 0, 0, 41];
+            let mut buf = vec![0, 0, 0, 41];
 
-	    buf.extend_from_slice(REPLY);
-	    tplink_api::encrypt(&mut buf[4..]);
+            buf.extend_from_slice(REPLY);
+            tplink_api::encrypt(&mut buf[4..]);
 
-	    assert!(buf.len() == 45);
-	    assert!(buf.as_slice().len() == 45);
+            assert!(buf.len() == 45);
+            assert!(buf.as_slice().len() == 45);
 
-	    assert!(Instance::read_reply(&mut &buf[0..4]).await.is_err());
-	    assert!(Instance::read_reply(&mut &buf[0..5]).await.is_err());
-	    assert!(Instance::read_reply(&mut buf.as_slice()).await.is_ok());
-	}
+            assert!(Instance::read_reply(&mut &buf[0..4]).await.is_err());
+            assert!(Instance::read_reply(&mut &buf[0..5]).await.is_err());
+            assert!(Instance::read_reply(&mut buf.as_slice()).await.is_ok());
+        }
     }
 }

--- a/drivers/drmem-drv-tplink/src/tplink_api.rs
+++ b/drivers/drmem-drv-tplink/src/tplink_api.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 // This is the encryption algorithm.
 
-fn encrypt(buf: &mut [u8]) {
+pub fn encrypt(buf: &mut [u8]) {
     let mut key = 171u8;
 
     for b in buf.iter_mut() {

--- a/drivers/drmem-drv-tplink/src/tplink_api.rs
+++ b/drivers/drmem-drv-tplink/src/tplink_api.rs
@@ -3,16 +3,45 @@
 // converted to the expected JSON layout.
 
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use std::{io::Write, marker::PhantomData};
 
-// This is the encryption algorithm.
+// This type allows us to write a TP-Link command into a vector in one
+// pass. When it is created, it contains the initial key. As data is
+// written, it is "encrypted" and the key is updated.
 
-pub fn encrypt(buf: &mut [u8]) {
-    let mut key = 171u8;
+pub struct CmdWriter<'a> {
+    key: u8,
+    buf: &'a mut Vec<u8>,
+}
 
-    for b in buf.iter_mut() {
-        key ^= *b;
-        *b = key;
+impl<'a> CmdWriter<'a> {
+    // Creates a new, initialized writer. The parameter is the vector
+    // that is to receive the encrypted data.
+
+    pub fn create(b: &'a mut Vec<u8>) -> Self {
+        CmdWriter { key: 171u8, buf: b }
+    }
+}
+
+impl Write for CmdWriter<'_> {
+    // This is a mandatory method, but it doesn't do anything.
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    // Writes a buffer of data to the vector. As the data is
+    // transferred, it is "encrypted". Returns the number of bytes
+    // written (which is always the number passed in.)
+
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        let sz = b.len();
+
+        for ii in b.iter() {
+            self.key ^= *ii;
+            self.buf.push(self.key);
+        }
+        Ok(sz)
     }
 }
 
@@ -80,9 +109,22 @@ pub enum Cmd {
 
 impl Cmd {
     pub fn encode(&self) -> Vec<u8> {
-        let mut buf = serde_json::to_vec(&self).unwrap();
+        let mut buf = Vec::with_capacity(100);
 
-        encrypt(&mut buf);
+        buf.push(0u8);
+        buf.push(0u8);
+        buf.push(0u8);
+        buf.push(0u8);
+
+        serde_json::to_writer(CmdWriter::create(&mut buf), &self).unwrap();
+
+        let sz = buf.len() - 4;
+
+        buf[0] = (sz >> 24) as u8;
+        buf[1] = (sz >> 16) as u8;
+        buf[2] = (sz >> 8) as u8;
+        buf[3] = sz as u8;
+
         buf
     }
 }
@@ -174,11 +216,16 @@ mod tests {
     #[test]
     fn test_crypt() {
         let buf = [1u8, 2u8, 3u8, 4u8, 5u8];
-        let mut buf2 = buf.clone();
+        let mut v: Vec<u8> = Vec::new();
 
-        encrypt(&mut buf2);
-        decrypt(&mut buf2);
-        assert_eq!(&buf, &buf2);
+        {
+            let mut wr = CmdWriter::create(&mut v);
+
+            assert_eq!(wr.write(&buf).unwrap(), 5);
+        }
+
+        decrypt(&mut v[..]);
+        assert_eq!(&buf, &v[..]);
     }
 
     #[test]

--- a/drmemd/Cargo.toml
+++ b/drmemd/Cargo.toml
@@ -23,7 +23,8 @@ futures.workspace = true
 
 toml = { workspace = true, features = ["parse"] }
 
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "fs"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time",
+"fs", "macros"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tracing.workspace = true
 tracing-futures = { workspace = true, features = ["std-future", "std"] }

--- a/drmemd/src/driver/drv_tod.rs
+++ b/drmemd/src/driver/drv_tod.rs
@@ -6,7 +6,6 @@ use drmem_api::{
 };
 use std::{convert::Infallible, future::Future, pin::Pin, sync::Arc};
 use tokio::{sync::Mutex, time};
-use tracing::info;
 
 pub struct Instance;
 


### PR DESCRIPTION
Fixes a bug introduced in 5f033095491b38d20427e04f283b8ad1cd280f29. I was trying to create a dynamically-sized buffer without resorting to `unsafe` code. But it didn't work. This pull request includes a test that will detect if the code breaks (if I try to improve it in the future.)