### PR TITLE
:wrench: add missing features

### DIFF
--- a/drivers/drmem-drv-ntp/Cargo.toml
+++ b/drivers/drmem-drv-ntp/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 [dependencies]
 toml.workspace = true
 
-tokio = { workspace = true, features = ["net", "io-util"] }
+tokio = { workspace = true, features = ["net", "io-util", "time", "macros"] }
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true

--- a/drivers/drmem-drv-sump/Cargo.toml
+++ b/drivers/drmem-drv-sump/Cargo.toml
@@ -18,7 +18,7 @@ socket2 = "0.5"
 
 toml.workspace = true
 
-tokio = { workspace = true, features = ["net", "io-util"] }
+tokio = { workspace = true, features = ["net", "io-util", "time"] }
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION
When publishing, several drivers failed to build because the were inheriting features from the workspace. This commit adds features to the drivers' `Cargo.toml` files so they can build on their own.