### PR TITLE
Improve weather driver

### DIFF
--- a/drivers/drmem-drv-weather-wu/Cargo.toml
+++ b/drivers/drmem-drv-weather-wu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drmem-drv-weather-wu"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Rich Neswold <rich.neswold@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/DrMemCS/drmem"


### PR DESCRIPTION
This version improves the `precip-rate`, `precip-total`, and `precip-last-total` devices.

Weather stations accumulate rainfall for 24 hours and reset the total at midnight. It doesn't matter how many separate storm systems occur, there's one total for the day.

This pull request identifies rainfall more than 10 hours apart as a separate event and updates the `precip-last-total` accordingly.