### PR TITLE
:sparkles: add `map` driver

### DIFF
--- a/drmem-api/Cargo.toml
+++ b/drmem-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drmem-api"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Rich Neswold <rich.neswold@gmail.com>"]
 edition = "2021"
 description = "Traits and types used internally by the DrMem control system"

--- a/drmem-api/src/types/device/value.rs
+++ b/drmem-api/src/types/device/value.rs
@@ -35,6 +35,19 @@ pub enum Value {
     Color(palette::LinSrgba<u8>),
 }
 
+impl Value {
+    pub fn is_same_type(&self, o: &Value) -> bool {
+        match (self, o) {
+            (Value::Bool(_), Value::Bool(_))
+            | (Value::Int(_), Value::Int(_))
+            | (Value::Flt(_), Value::Flt(_))
+            | (Value::Str(_), Value::Str(_))
+            | (Value::Color(_), Value::Color(_)) => true,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/drmemd/Cargo.toml
+++ b/drmemd/Cargo.toml
@@ -43,7 +43,7 @@ palette.workspace = true
 
 lazy_static = "1"
 
-drmem-api = { path = "../drmem-api", version = "0.4" }
+drmem-api = { path = "../drmem-api", version = "0.4.1" }
 
 cfgrammar = "0.13"
 lrlex = "0.13"

--- a/drmemd/src/driver/drv_map.md
+++ b/drmemd/src/driver/drv_map.md
@@ -1,0 +1,39 @@
+# drmem-drv-map
+
+A map device is a driver that maps a range of integers to a device
+value. The driver creates two devices, `index` and `output`. When the
+`index` is set, the driver finds the associated value and write both
+of them to the backend storage. Every setting will get sent to the
+backend -- even if the new value is the same as the old.
+
+## Configuration
+
+The configuration parameters for this driver are:
+
+- `initial` is an optional parameter. It is an integer which specifies
+  the initial index to use when the driver starts. If no initial value
+  is specified, the `output` device will be set to the default value.
+- `values` is an array of maps. Each map has three key/values: 1)
+  'start' is an integer specifying the start of the index range, `end`
+  is an optional parameter specifying the ending range, inclusive (if
+  omitted, `end` is the same as `start`), and `value` is a value to
+  output when the index device is set within this range.
+- `default` is the value that will be used if the `index` device gets
+  set to a value that doesn't lie within any range.
+
+NOTE: when the driver starts, it makes sure that no range in the
+`values` array overlaps any other range. It also makes sure that all
+the values in the array and the default value are of the same type.
+
+## Devices
+
+The driver creates these devices:
+
+| Base Name | Type       | Units | Comment                                                      |
+|-----------|------------|-------|--------------------------------------------------------------|
+| index  | integer, RW |       | The index value used to look up a value in the map. |
+| output | VALUE, RO   |       | This device gets updated everytime the `index` device gets updated. It gets set to the value determined by the map lookup. If the index didn't lie in any range, it gets set to the default value. |
+
+## History
+
+Added in v0.4.0.

--- a/drmemd/src/driver/drv_map.rs
+++ b/drmemd/src/driver/drv_map.rs
@@ -1,0 +1,367 @@
+use drmem_api::{
+    device,
+    driver::{self, DriverConfig},
+    Error, Result,
+};
+use std::{
+    convert::Infallible, future::Future, ops::RangeInclusive, pin::Pin,
+    sync::Arc,
+};
+use tokio::sync::Mutex;
+use tokio_stream::StreamExt;
+
+#[derive(Debug, PartialEq)]
+struct Entry(RangeInclusive<i32>, device::Value);
+
+pub struct Instance {
+    init_index: Option<i32>,
+    def_val: device::Value,
+    values: Vec<Entry>,
+}
+
+pub struct Devices {
+    d_output: driver::ReportReading<device::Value>,
+    d_index: driver::ReportReading<i32>,
+    s_index: driver::SettingStream<i32>,
+}
+
+impl Instance {
+    pub const NAME: &'static str = "map";
+
+    pub const SUMMARY: &'static str = "Maps a range of indices to a value.";
+
+    pub const DESCRIPTION: &'static str = include_str!("drv_map.md");
+
+    /// Creates a new `Instance` instance.
+
+    fn new(
+        init_index: Option<i32>,
+        def_val: device::Value,
+        values: Vec<Entry>,
+    ) -> Instance {
+        Instance {
+            init_index,
+            def_val,
+            values,
+        }
+    }
+
+    // Gets the initial value of the index from the configuration.
+
+    fn get_cfg_init_val(cfg: &DriverConfig) -> Result<Option<i32>> {
+        match cfg.get("initial") {
+            Some(toml::value::Value::Integer(v))
+                if *v >= (i32::MIN as i64) && *v <= (i32::MAX as i64) =>
+            {
+                Ok(Some(*v as i32))
+            }
+            Some(_) => Err(Error::ConfigError(
+                "'initial' config parameter should be a 32-bit integer".into(),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    fn get_cfg_def_val(cfg: &DriverConfig) -> Result<device::Value> {
+        cfg.get("default")
+            .ok_or_else(|| {
+                Error::ConfigError(
+                    "`default` config parameter is missing".into(),
+                )
+            })
+            .and_then(|v| {
+                device::Value::try_from(v).map_err(|e| {
+                    Error::ConfigError(format!(
+                        "`default` config paramter : {}",
+                        e
+                    ))
+                })
+            })
+    }
+
+    fn to_entry(tbl: &toml::Table) -> Result<Entry> {
+        if let Some(toml::value::Value::Integer(start)) = tbl.get("start") {
+            if let Some(value) = tbl.get("value") {
+                let value = device::Value::try_from(value).map_err(|_| {
+                    Error::ConfigError(
+                        "`values` array entry contains unknown `value` type"
+                            .into(),
+                    )
+                })?;
+
+                let start = *start as i32;
+
+                match tbl.get("end") {
+                    Some(toml::value::Value::Integer(end)) => {
+                        let end = *end as i32;
+
+                        Ok(Entry(start.min(end)..=start.max(end), value))
+                    }
+                    Some(_) => Err(Error::ConfigError(
+                        "`values` array entry has a bad `end` value".into(),
+                    )),
+                    None => Ok(Entry(start..=start, value)),
+                }
+            } else {
+                Err(Error::ConfigError(
+                    "`values` array entry missing `value`".into(),
+                ))
+            }
+        } else {
+            Err(Error::ConfigError(
+                "`values` array entry missing `start`".into(),
+            ))
+        }
+    }
+
+    fn get_cfg_values(cfg: &DriverConfig) -> Result<Vec<Entry>> {
+        match cfg.get("values") {
+            Some(toml::value::Value::Array(arr)) if !arr.is_empty() => {
+                let mut result = vec![];
+
+                for entry in arr {
+                    match entry {
+                        toml::value::Value::Table(tbl) => {
+                            result.push(Self::to_entry(tbl)?)
+                        }
+                        _ => {
+                            return Err(Error::ConfigError(
+                                "`values` array contains a non-table".into(),
+                            ))
+                        }
+                    }
+                }
+
+                Ok(result)
+            }
+            Some(_) => Err(Error::ConfigError(
+                "`values` config parameter should be a non-empty array of maps"
+                    .into(),
+            )),
+            None => Err(Error::ConfigError(
+                "`values` config parameter is missing".into(),
+            )),
+        }
+    }
+
+    // Find the entry that contains the index. Return the associated
+    // value. If no entry matches, return the error value.
+
+    fn map_to(&self, idx: i32) -> device::Value {
+        self.values
+            .iter()
+            .find(|e| e.0.contains(&idx))
+            .map(|e| e.1.clone())
+            .unwrap_or_else(|| self.def_val.clone())
+    }
+}
+
+impl driver::API for Instance {
+    type DeviceSet = Devices;
+
+    fn register_devices(
+        core: driver::RequestChan,
+        _cfg: &DriverConfig,
+        max_history: Option<usize>,
+    ) -> Pin<Box<dyn Future<Output = Result<Self::DeviceSet>> + Send>> {
+        let output_name = "output".parse::<device::Base>().unwrap();
+        let index_name = "index".parse::<device::Base>().unwrap();
+
+        Box::pin(async move {
+            // Define the devices managed by this driver.
+            //
+            // This first device is the output of the map.
+
+            let (d_output, _) =
+                core.add_ro_device(output_name, None, max_history).await?;
+
+            // This device is settable. Any setting is forwarded to
+            // the backend.
+
+            let (d_index, s_index, _) =
+                core.add_rw_device(index_name, None, max_history).await?;
+
+            Ok(Devices {
+                d_output,
+                d_index,
+                s_index,
+            })
+        })
+    }
+
+    fn create_instance(
+        cfg: &DriverConfig,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<Self>>> + Send>> {
+        let init_index = Instance::get_cfg_init_val(cfg);
+        let def_value = Instance::get_cfg_def_val(cfg);
+        let values = Instance::get_cfg_values(cfg);
+
+        Box::pin(async move {
+            Ok(Box::new(Instance::new(init_index?, def_value?, values?)))
+        })
+    }
+
+    fn run<'a>(
+        &'a mut self,
+        devices: Arc<Mutex<Self::DeviceSet>>,
+    ) -> Pin<Box<dyn Future<Output = Infallible> + Send + 'a>> {
+        let fut = async move {
+            let mut devices = devices.lock().await;
+
+            // If we have an initial value, use it.
+
+            if let Some(idx) = self.init_index {
+                // Send the updated values to the backend.
+
+                (devices.d_output)(self.map_to(idx)).await;
+                (devices.d_index)(idx).await
+            } else {
+                (devices.d_output)(self.def_val.clone()).await;
+            }
+
+            // The driver blocks, waiting for a new index. As long as
+            // our setting channel is healthy, we handle each setting.
+
+            while let Some((v, reply)) = devices.s_index.next().await {
+                // Send the reply to the setter.
+
+                reply(Ok(v.clone()));
+
+                // Send the updated values to the backend.
+
+                (devices.d_output)(self.map_to(v)).await;
+                (devices.d_index)(v).await
+            }
+            panic!("can no longer receive settings");
+        };
+
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Entry, Instance};
+    use drmem_api::device;
+    use toml::value::{Table, Value};
+
+    #[test]
+    fn test_cfg_initial() {
+        let mut tbl = Table::new();
+
+        assert_eq!(Instance::get_cfg_init_val(&tbl), Ok(None));
+
+        let _ = tbl.insert("initial".into(), Value::String("hello".into()));
+
+        assert!(Instance::get_cfg_init_val(&tbl).is_err());
+
+        let _ = tbl.insert("initial".into(), Value::Integer(100));
+
+        assert_eq!(Instance::get_cfg_init_val(&tbl), Ok(Some(100)));
+    }
+
+    #[test]
+    fn test_cfg_default() {
+        let mut tbl = Table::new();
+
+        assert!(Instance::get_cfg_def_val(&tbl).is_err());
+
+        let _ = tbl.insert("default".into(), Value::String("hello".into()));
+
+        assert_eq!(
+            Instance::get_cfg_def_val(&tbl),
+            Ok(device::Value::Str("hello".into()))
+        );
+    }
+
+    fn build_table(
+        start: Option<i64>,
+        end: Option<i64>,
+        val: Option<Value>,
+    ) -> Value {
+        let mut tbl = Table::new();
+
+        if let Some(start) = start {
+            let _ = tbl.insert("start".into(), Value::Integer(start));
+        }
+
+        if let Some(val) = val {
+            let _ = tbl.insert("value".into(), val);
+        }
+
+        if let Some(end) = end {
+            let _ = tbl.insert("end".into(), Value::Integer(end));
+        }
+
+        Value::Table(tbl)
+    }
+
+    #[test]
+    fn test_cfg_values() {
+        {
+            let mut tbl = Table::new();
+
+            // First test for bad configurations.
+            //
+            // This tests that a missing "values" key is an error.
+
+            assert!(Instance::get_cfg_values(&tbl).is_err());
+
+            // Tests if the range entry is missing a "start" key.
+
+            let _ = tbl.insert(
+                "values".into(),
+                Value::Array(vec![build_table(None, None, None)]),
+            );
+
+            assert!(Instance::get_cfg_values(&tbl).is_err());
+
+            // Tests if the range entry is missing a "value" key.
+
+            let _ = tbl.insert(
+                "values".into(),
+                Value::Array(vec![build_table(Some(0), None, None)]),
+            );
+
+            assert!(Instance::get_cfg_values(&tbl).is_err());
+        }
+
+        // Now test good configurations.
+
+        {
+            let mut tbl = Table::new();
+
+            // Test that providing all fields generates a entry.
+
+            let _ = tbl.insert(
+                "values".into(),
+                Value::Array(vec![build_table(
+                    Some(0),
+                    Some(10),
+                    Some(Value::String("hello".into())),
+                )]),
+            );
+
+            assert_eq!(
+                Instance::get_cfg_values(&tbl).unwrap(),
+                vec![Entry(0..=10, device::Value::Str("hello".into()))]
+            );
+
+            // Test that omitting the "end" set it equal to "start".
+
+            let _ = tbl.insert(
+                "values".into(),
+                Value::Array(vec![build_table(
+                    Some(0),
+                    None,
+                    Some(Value::String("hello".into())),
+                )]),
+            );
+
+            assert_eq!(
+                Instance::get_cfg_values(&tbl).unwrap(),
+                vec![Entry(0..=0, device::Value::Str("hello".into()))]
+            );
+        }
+    }
+}

--- a/drmemd/src/driver/mod.rs
+++ b/drmemd/src/driver/mod.rs
@@ -7,6 +7,7 @@ use tracing::{error, field, info, info_span, warn};
 use tracing_futures::Instrument;
 
 mod drv_cycle;
+mod drv_map;
 mod drv_memory;
 mod drv_timer;
 
@@ -147,6 +148,19 @@ impl DriverDb {
 
         {
             use drv_memory::Instance;
+
+            table.insert(
+                Instance::NAME.into(),
+                (
+                    Instance::SUMMARY,
+                    Instance::DESCRIPTION,
+                    manage_instance::<Instance>,
+                ),
+            );
+        }
+
+        {
+            use drv_map::Instance;
 
             table.insert(
                 Instance::NAME.into(),


### PR DESCRIPTION
This adds the map driver to DrMem. This is another internal driver that is always available (it's considered one of the "building block" drivers, like the `timer`, `cycle`, and `memory` drivers.)