### PR TITLE
:wrench: don't run unit tests when merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,9 @@ on:
         type: string
         required: false
         default: stable
-  push:
-    branches: [ "main", "pr-*" ]
   pull_request:
-    branches: [ "main", "pr-*" ]
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
No need to run the unit tests once the pull request was successful.