### PR TITLE
:sparkles: add `if-then-else` to grammar

### DIFF
--- a/drmemd/src/logic/logic.l
+++ b/drmemd/src/logic/logic.l
@@ -12,6 +12,11 @@ not                     "B_NOT"
 and                     "B_AND"
 or                      "B_OR"
 
+[Ii][Ff]                "KW_IF"
+[Tt][Hh][Ee][Nn]        "KW_THEN"
+[Ee][Ll][Ss][Ee]        "KW_ELSE"
+[Ee][Nn][Dd]            "KW_END"
+
 =                       "EQ"
 \<>                     "NE"
 \<=                     "LT_EQ"


### PR DESCRIPTION
This adds a conditional expression to the grammar. If you don't specify an `else` expression, the result is `None`. This "feature" removed the need of adding an "ignore" keyword, so this pull request closes two issues! 🎉