### PR TITLE
Pull request

### DIFF
--- a/drivers/drmem-drv-tplink/src/config.rs
+++ b/drivers/drmem-drv-tplink/src/config.rs
@@ -2,9 +2,13 @@ use drmem_api::{driver::DriverConfig, Error};
 use std::net::SocketAddrV4;
 
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DevCfgType {
+    #[serde(alias = "Switch", alias = "SWITCH")]
     Switch,
+    #[serde(alias = "Outlet", alias = "OUTLET")]
     Outlet,
+    #[serde(alias = "Dimmer", alias = "DIMMER")]
     Dimmer,
 }
 

--- a/drmemd/src/driver/mod.rs
+++ b/drmemd/src/driver/mod.rs
@@ -21,7 +21,7 @@ pub type Launcher<R> = fn(
     driver::DriverConfig,
     driver::RequestChan<R>,
     Option<usize>,
-    barrier: Arc<Barrier>,
+    Arc<Barrier>,
 ) -> MgrTask;
 
 type DriverInfo<R> = (&'static str, &'static str, Launcher<R>);
@@ -110,9 +110,10 @@ where
     Box::pin(async move {
         let cfg = match T::Config::try_from(cfg) {
             Ok(cfg) => Ok(cfg),
-            err @ Err(_) => {
+            Err(e) => {
+                error!("config error -- {}", &e);
                 barrier.wait().await;
-                err
+                Err(e)
             }
         }?;
 


### PR DESCRIPTION
The AI sessions were very helpful. Switching over to using `serde` for parsing the driver configs  -- although a big win -- broke my `drmem.toml` because `serde` forces the case to match the enum variant. This PR configures `serde` to deserialize using several useful case combinations.