### PR TITLE
:sparkles: add internal `counter` driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,18 @@ currently supported features:
   - A back-end which writes device information to a Redis server
 - A client API which uses GraphQL
 - Drivers which implement devices
-  - 5 built-in drivers
-    - Memory devices
-	- Cycling device
-	- Timer device
+  - 6 built-in drivers
+    - Counting device
+	  - Cycling device
     - Latch device
-	- Map device (maps ranges of integers to values)
+	  - Map device (maps ranges of integers to values)
+    - Memory devices
+	  - Timer device
   - 4 external drivers
     - Weather Underground data
-	- NTP daemon status
-	- TP-Link support (tested with an HS440 Kasa light dimmer)
-	- (Author's) custom sump pump monitor
+	  - NTP daemon status
+	  - TP-Link support (tested with an HS440 Kasa light dimmer)
+	  - (Author's) custom sump pump monitor
 - A "logic block" module that lets you define logic so that control loops
   can be set up internally, instead of requiring external client applications
   to do the controlling.

--- a/drmemd/src/driver/counter/config.rs
+++ b/drmemd/src/driver/counter/config.rs
@@ -1,0 +1,12 @@
+use drmem_api::{driver::DriverConfig, Error};
+
+#[derive(serde::Deserialize)]
+pub struct Params;
+
+impl TryFrom<DriverConfig> for Params {
+    type Error = Error;
+
+    fn try_from(_cfg: DriverConfig) -> std::result::Result<Self, Self::Error> {
+        Ok(Params)
+    }
+}

--- a/drmemd/src/driver/counter/device.rs
+++ b/drmemd/src/driver/counter/device.rs
@@ -1,0 +1,46 @@
+use drmem_api::{
+    driver::{self, Reporter, ResettableState},
+    Result,
+};
+
+use super::config;
+
+pub struct Set<R: Reporter> {
+    pub d_count: driver::ReadOnlyDevice<i32, R>,
+    pub d_increment: driver::ReadWriteDevice<bool, R>,
+    pub d_reset: driver::ReadWriteDevice<bool, R>,
+}
+
+impl<R: Reporter> driver::Registrator<R> for Set<R> {
+    type Config = config::Params;
+
+    async fn register_devices(
+        core: &mut driver::RequestChan<R>,
+        _cfg: &Self::Config,
+        max_history: Option<usize>,
+    ) -> Result<Self> {
+        // Define the devices managed by this driver.
+        //
+        // This first device is the count value.
+
+        let d_count = core.add_ro_device("count", None, max_history).await?;
+
+        // Any time it transitions from `false` to `true`, the count increases
+        // by one.
+
+        let d_increment =
+            core.add_rw_device("increment", None, max_history).await?;
+
+        // Any time it transitions from `false` to `true`, the count resets to 0.
+
+        let d_reset = core.add_rw_device("reset", None, max_history).await?;
+
+        Ok(Set {
+            d_count,
+            d_increment,
+            d_reset,
+        })
+    }
+}
+
+impl<R: Reporter> ResettableState for Set<R> {}

--- a/drmemd/src/driver/counter/driver.rs
+++ b/drmemd/src/driver/counter/driver.rs
@@ -89,7 +89,7 @@ impl<R: Reporter> driver::API<R> for Instance {
                 }
                 Some((b, reply)) = devices.d_reset.next_setting() => {
                     // Record all settings.
-                    
+
                     devices.d_reset.report_update(b).await;
 
                     // Reset and report the new count.

--- a/drmemd/src/driver/counter/driver.rs
+++ b/drmemd/src/driver/counter/driver.rs
@@ -1,0 +1,132 @@
+use drmem_api::{
+    driver::{self, Reporter},
+    Result,
+};
+use std::convert::Infallible;
+
+use super::{config, device};
+
+// The state of a driver instance.
+
+pub enum Instance {
+    Waiting(i32),
+    Tripped(i32),
+}
+
+impl Instance {
+    pub const NAME: &'static str = "counter";
+
+    pub const SUMMARY: &'static str = "Counts events that have occurred";
+
+    pub const DESCRIPTION: &'static str = include_str!("drv_counter.md");
+
+    /// Creates a new, idle `Instance`.
+    pub fn new() -> Instance {
+        Instance::Waiting(0)
+    }
+
+    pub fn incrememt(&mut self, val: bool) -> Option<i32> {
+        match self {
+            Instance::Waiting(count) => {
+                if val {
+                    let temp = *count + 1;
+
+                    *self = Instance::Tripped(temp);
+                    return Some(temp);
+                }
+            }
+            Instance::Tripped(count) => {
+                if !val {
+                    *self = Instance::Waiting(*count);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn reset(&mut self, val: bool) {
+        if val {
+            *self = Instance::Waiting(0);
+        }
+    }
+
+    pub fn get_count(&self) -> i32 {
+        match self {
+            Instance::Waiting(count) => *count,
+            Instance::Tripped(count) => *count,
+        }
+    }
+}
+
+impl<R: Reporter> driver::API<R> for Instance {
+    type Config = config::Params;
+    type HardwareType = device::Set<R>;
+
+    async fn create_instance(_cfg: &Self::Config) -> Result<Box<Self>> {
+        Ok(Box::new(Instance::new()))
+    }
+
+    async fn run(&mut self, devices: &mut Self::HardwareType) -> Infallible {
+        devices.d_count.report_update(self.get_count()).await;
+
+        loop {
+            #[rustfmt::skip]
+            tokio::select! {
+                Some((b, reply)) = devices.d_increment.next_setting() => {
+                    // Record all settings.
+
+                    devices.d_increment.report_update(b).await;
+
+                    // Possibly update the count. If it is incrmented, report it.
+
+                    if let Some(count) = self.incrememt(b) {
+                        devices.d_count.report_update(count).await;
+                    }
+
+                    // Notify the client.
+
+                    reply.ok(b)
+                }
+                Some((b, reply)) = devices.d_reset.next_setting() => {
+                    // Record all settings.
+                    
+                    devices.d_reset.report_update(b).await;
+
+                    // Reset and report the new count.
+
+                    self.reset(b);
+                    devices.d_count.report_update(0).await;
+
+                    // Notify the client.
+
+                    reply.ok(b);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_changes() {
+        let mut counter = Instance::new();
+
+        assert_eq!(counter.get_count(), 0);
+        assert_eq!(counter.incrememt(false), None);
+        assert_eq!(counter.incrememt(true), Some(1));
+        assert_eq!(counter.incrememt(false), None);
+        assert_eq!(counter.incrememt(true), Some(2));
+        assert_eq!(counter.incrememt(false), None);
+        counter.reset(false);
+        assert_eq!(counter.get_count(), 2);
+        counter.reset(true);
+        assert_eq!(counter.get_count(), 0);
+        counter.reset(false);
+        assert_eq!(counter.get_count(), 0);
+        assert_eq!(counter.incrememt(false), None);
+        assert_eq!(counter.incrememt(true), Some(1));
+    }
+}

--- a/drmemd/src/driver/counter/drv_counter.md
+++ b/drmemd/src/driver/counter/drv_counter.md
@@ -1,0 +1,23 @@
+# drmem-drv-counter
+
+Implements a counter that increments when the `increment` input transitions from `false` to `true`. A `reset` input will set the count to 0 when `true`.
+
+This driver is always available in DrMem.
+
+## Configuration
+
+This driver has no configuration parameters.
+
+## Devices
+
+The driver creates these devices:
+
+| Base Name | Type     | Units | Comment                                                |
+|-----------|----------|-------|--------------------------------------------------------|
+| `increment`  | bool, RW |       | A `false` to `true` transition will increment the count. |
+| `reset`  | bool, RW |       | Setting to `true` will reset the count to 0. |
+| `count`  | int, RO    |       | The current count. |
+
+## History
+
+Added in v0.7.0.

--- a/drmemd/src/driver/counter/mod.rs
+++ b/drmemd/src/driver/counter/mod.rs
@@ -1,0 +1,5 @@
+mod config;
+mod device;
+mod driver;
+
+pub use driver::Instance;

--- a/drmemd/src/driver/mod.rs
+++ b/drmemd/src/driver/mod.rs
@@ -8,6 +8,7 @@ use std::{convert::Infallible, pin::Pin, sync::Arc};
 use tokio::sync::Barrier;
 use tracing::{error, field, info, info_span, warn, Instrument};
 
+mod counter;
 mod cycle;
 mod latch;
 mod map;
@@ -197,6 +198,19 @@ impl<R: Reporter> DriverDb<R> {
 
         {
             use cycle::Instance;
+
+            table.insert(
+                Instance::NAME.into(),
+                (
+                    Instance::SUMMARY,
+                    Instance::DESCRIPTION,
+                    manage_instance::<Instance, R>,
+                ),
+            );
+        }
+
+        {
+            use counter::Instance;
 
             table.insert(
                 Instance::NAME.into(),


### PR DESCRIPTION
Creates a new, internal driver that counts events.